### PR TITLE
Fix relative path handling for attachment locations

### DIFF
--- a/src/ui/publishSettingTab.ts
+++ b/src/ui/publishSettingTab.ts
@@ -30,7 +30,9 @@ export default class PublishSettingTab extends PluginSettingTab {
                     .setPlaceholder("Enter folder name")
                     .setValue(this.plugin.settings.attachmentLocation)
                     .onChange(async (value) => {
-                        if ((await this.app.vault.getAbstractFileByPath(value)) == null) {
+                        const isRelativePath = value.match(/^\./)
+                        const pathExist = this.app.vault.getAbstractFileByPath(value)
+                        if (!isRelativePath && !pathExist) {
                             new Notice(`Attachment location "${value}" not exist!`)
                             return
                         }

--- a/src/uploader/imageTagProcessor.ts
+++ b/src/uploader/imageTagProcessor.ts
@@ -190,18 +190,25 @@ export default class ImageTagProcessor {
             return {resolvedPath: imagePath, name: pathName};
         }
         
-        let finalPathName = pathName;
-        if (pathName.startsWith('./')) {
-            finalPathName = pathName.substring(2);
-        }
-        
+        // If not found at the attachment location, try relative to the current file
         const activeFile = this.app.workspace.getActiveFile();
         if (!activeFile || !activeFile.parent) {
             throw new Error("No active file found");
         }
         
         const parentPath = activeFile.parent.path;
-        return {resolvedPath: path.join(parentPath, finalPathName), name: finalPathName};
+        let finalImagePath: string;
+        
+        // If attachment location starts with './', resolve it relative to the current file's directory
+        if (this.settings.attachmentLocation.startsWith('./')) {
+            const relativeAttachmentPath = this.settings.attachmentLocation.substring(2);
+            finalImagePath = path.join(parentPath, relativeAttachmentPath, pathName);
+        } else {
+            // Fallback: just join with parent path
+            finalImagePath = path.join(parentPath, pathName);
+        }
+        
+        return {resolvedPath: finalImagePath, name: pathName};
     }
 
     private getValue(): string {


### PR DESCRIPTION
This PR adds support for use case identified in issue #29, where relative attachment paths (starting with ```./```) weren't properly resolved in the image tag processor.

**Changes:**
- Updated validation logic in ```publishSettingTab.ts``` to allow relative paths without requiring folder existence check
- Enhanced path resolution in ```imageTagProcessor.ts``` to correctly handle relative attachment locations by resolving them relative to the current file's directory

**Manual testing done:**
- Verified relative paths like ```./attachments``` now resolve correctly
- Existing absolute path functionality remains unchanged

The fix ensures attachment location settings work consistently whether using absolute vault paths or relative paths from the current file.

