### PR TITLE
feat: Add Backblaze B2 storage support

### DIFF
--- a/src/imageStore.ts
+++ b/src/imageStore.ts
@@ -44,6 +44,11 @@ export default class ImageStore {
         "CLOUDFLARE_R2",
         "Cloudflare R2"
     )
+    
+    static readonly BACKBLAZE_B2 = new ImageStore(
+        "BACKBLAZE_B2",
+        "Backblaze B2"
+    )
 
     private constructor(readonly id: string, readonly description: string) {
         ImageStore.values.push(this)

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -17,6 +17,7 @@ import {CosSetting} from "./uploader/cos/cosUploader";
 import {KodoSetting} from "./uploader/qiniu/kodoUploader";
 import {GitHubSetting} from "./uploader/github/gitHubUploader";
 import {R2Setting} from "./uploader/r2/r2Uploader";
+import {B2Setting} from "./uploader/b2/b2Uploader";
 
 export interface PublishSettings {
     imageAltText: boolean;
@@ -34,6 +35,7 @@ export interface PublishSettings {
     kodoSetting: KodoSetting;
     githubSetting: GitHubSetting;
     r2Setting: R2Setting;
+    b2Setting: B2Setting;
 }
 
 const DEFAULT_SETTINGS: PublishSettings = {
@@ -93,6 +95,14 @@ const DEFAULT_SETTINGS: PublishSettings = {
         accessKeyId: "",
         secretAccessKey: "",
         endpoint: "",
+        bucketName: "",
+        path: "",
+        customDomainName: "",
+    },
+    b2Setting: {
+        accessKeyId: "",
+        secretAccessKey: "",
+        region: "",
         bucketName: "",
         path: "",
         customDomainName: "",

--- a/src/ui/publishSettingTab.ts
+++ b/src/ui/publishSettingTab.ts
@@ -118,6 +118,9 @@ export default class PublishSettingTab extends PluginSettingTab {
             case ImageStore.CLOUDFLARE_R2.id:
                 this.drawR2Setting(parentEL);
                 break;
+            case ImageStore.BACKBLAZE_B2.id:
+                this.drawB2Setting(parentEL);
+                break;
             default:
                 throw new Error(
                     "Should not reach here!"
@@ -520,5 +523,59 @@ export default class PublishSettingTab extends PluginSettingTab {
                     .setPlaceholder("Enter domain name")
                     .setValue(this.plugin.settings.r2Setting.customDomainName)
                     .onChange(value => this.plugin.settings.r2Setting.customDomainName = value));
+    }
+
+    private drawB2Setting(parentEL: HTMLDivElement) {
+        new Setting(parentEL)
+            .setName('Backblaze B2 Access Key ID')
+            .setDesc('Your Backblaze B2 application key ID')
+            .addText(text => text
+                .setPlaceholder('Enter your application key ID')
+                .setValue(this.plugin.settings.b2Setting?.accessKeyId || '')
+                .onChange(value => this.plugin.settings.b2Setting.accessKeyId = value
+                ));
+
+        new Setting(parentEL)
+            .setName('Backblaze B2 Secret Access Key')
+            .setDesc('Your Backblaze B2 application key')
+            .addText(text => text
+                .setPlaceholder('Enter your application key')
+                .setValue(this.plugin.settings.b2Setting?.secretAccessKey || '')
+                .onChange(value => this.plugin.settings.b2Setting.secretAccessKey = value));
+
+        new Setting(parentEL)
+            .setName('Backblaze B2 Region')
+            .setDesc('Your Backblaze B2 region (e.g., us-west-004)')
+            .addText(text => text
+                .setPlaceholder('Enter your region')
+                .setValue(this.plugin.settings.b2Setting?.region || '')
+                .onChange(value => this.plugin.settings.b2Setting.region = value));
+
+        new Setting(parentEL)
+            .setName('Backblaze B2 Bucket Name')
+            .setDesc('Your Backblaze B2 bucket name')
+            .addText(text => text
+                .setPlaceholder('Enter your bucket name')
+                .setValue(this.plugin.settings.b2Setting?.bucketName || '')
+                .onChange(value => this.plugin.settings.b2Setting.bucketName = value));
+
+        new Setting(parentEL)
+            .setName("Target Path")
+            .setDesc("The path to store image.\nSupport {year} {mon} {day} {random} {filename} vars. For example, /{year}/{mon}/{day}/{filename} with uploading pic.jpg, it will store as /2023/06/08/pic.jpg.")
+            .addText(text =>
+                text
+                    .setPlaceholder("Enter path")
+                    .setValue(this.plugin.settings.b2Setting.path)
+                    .onChange(value => this.plugin.settings.b2Setting.path = value));
+
+        //custom domain
+        new Setting(parentEL)
+            .setName("Custom Domain Name")
+            .setDesc("If you have configured a custom domain, you can use https://example.com/pic.jpg to access pic.img. Otherwise, leave it empty to use the default B2 URL.")
+            .addText(text =>
+                text
+                    .setPlaceholder("Enter custom domain (optional)")
+                    .setValue(this.plugin.settings.b2Setting.customDomainName)
+                    .onChange(value => this.plugin.settings.b2Setting.customDomainName = value));
     }
 }

--- a/src/uploader/b2/b2Uploader.ts
+++ b/src/uploader/b2/b2Uploader.ts
@@ -1,0 +1,65 @@
+import ImageUploader from "../imageUploader";
+import AWS from 'aws-sdk';
+import {UploaderUtils} from "../uploaderUtils";
+
+export default class B2Uploader implements ImageUploader {
+  private readonly s3!: AWS.S3;
+  private readonly bucket!: string;
+  private pathTmpl: string;
+  private customDomainName: string;
+
+  constructor(setting: B2Setting) {
+    this.s3 = new AWS.S3({
+      accessKeyId: setting.accessKeyId,
+      secretAccessKey: setting.secretAccessKey,
+      endpoint: `https://s3.${setting.region}.backblazeb2.com`,
+      region: setting.region,
+      s3ForcePathStyle: true,
+      signatureVersion: 'v4',
+    });
+    this.bucket = setting.bucketName;
+    this.pathTmpl = setting.path;
+    this.customDomainName = setting.customDomainName;
+  }
+
+  async upload(image: File, fullPath: string): Promise<string> {
+    const arrayBuffer = await this.readFileAsArrayBuffer(image);
+    const uint8Array = new Uint8Array(arrayBuffer);
+    var path = UploaderUtils.generateName(this.pathTmpl, image.name);
+    path = path.replace(/^\/+/, ''); // remove the /
+    const params = {
+      Bucket: this.bucket,
+      Key: path,
+      Body: uint8Array,
+      ContentType: `image/${image.name.split('.').pop()}`,
+    };
+    return new Promise((resolve, reject) => {
+      this.s3.upload(params, (err, data) => {
+        if (err) {
+          reject(err);
+        } else {
+          const dst = data.Location.split(`/${this.bucket}/`).pop();
+          resolve(UploaderUtils.customizeDomainName(dst, this.customDomainName));
+        }
+      });
+    });
+  }
+
+  private readFileAsArrayBuffer(file: File): Promise<ArrayBuffer> {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result as ArrayBuffer);
+      reader.onerror = reject;
+      reader.readAsArrayBuffer(file);
+    });
+  }
+}
+
+export interface B2Setting {
+  accessKeyId: string;
+  secretAccessKey: string;
+  region: string;
+  bucketName: string;
+  path: string;
+  customDomainName: string;
+}

--- a/src/uploader/imageUploaderBuilder.ts
+++ b/src/uploader/imageUploaderBuilder.ts
@@ -9,6 +9,7 @@ import CosUploader from "./cos/cosUploader";
 import KodoUploader from "./qiniu/kodoUploader";
 import GitHubUploader from "./github/gitHubUploader";
 import R2Uploader from "./r2/r2Uploader";
+import B2Uploader from "./b2/b2Uploader";
 
 export default function buildUploader(settings: PublishSettings): ImageUploader {
     switch (settings.imageStore) {
@@ -28,6 +29,8 @@ export default function buildUploader(settings: PublishSettings): ImageUploader 
             return new GitHubUploader(settings.githubSetting);
         case ImageStore.CLOUDFLARE_R2.id:
             return new R2Uploader(settings.r2Setting);
+        case ImageStore.BACKBLAZE_B2.id:
+            return new B2Uploader(settings.b2Setting);
         //todo more cases
         default:
             throw new Error('should not reach here!')


### PR DESCRIPTION
## 🎉 Add Backblaze B2 Storage Support

This PR adds support for Backblaze B2 Cloud Storage as requested in #44.

### Changes
- ✅ Implement `B2Uploader` using S3-compatible API
- ✅ Add Backblaze B2 to ImageStore options
- ✅ Add B2 settings UI (region, credentials, bucket, path, custom domain)
- ✅ Support all standard features (path templates with variables, custom domains)

### Technical Details
Backblaze B2 is S3-compatible, similar to Cloudflare R2. The implementation:
- Uses AWS SDK S3 client
- Endpoint format: `https://s3.<region>.backblazeb2.com`
- Supports signature v4
- Uses path-style addressing (`s3ForcePathStyle: true`)

### Configuration Required
Users will need:
1. **Application Key ID** (from B2 console)
2. **Application Key** (secret)
3. **Region** (e.g., `us-west-004`)
4. **Bucket Name**
5. **Optional**: Custom domain for prettier URLs

### Testing
The code follows the same pattern as existing R2 and AWS S3 uploaders, which are already working in production.

Closes #44

### References
- [Backblaze B2 S3-Compatible API Documentation](https://www.backblaze.com/docs/cloud-storage-s3-compatible-api)
- [AWS CLI with B2 Guide](https://www.backblaze.com/docs/cloud-storage-use-the-aws-cli-with-backblaze-b2)