### PR TITLE
refactor(imagekit): use Obsidian's requestUrl method to upload image instead of using imagekit SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "devDependencies": {
     "@types/node": "^14.14.2",
+    "esbuild": "^0.18.20",
     "obsidian": "obsidianmd/obsidian-api",
     "obsidian-plugin-cli": "^0.4.3",
     "typescript": "^4.0.3"

--- a/src/uploader/imagekit/imagekitUploader.ts
+++ b/src/uploader/imagekit/imagekitUploader.ts
@@ -1,36 +1,61 @@
 import ImageUploader from "../imageUploader";
-import Imagekit from "imagekit";
+import { requestUrl } from "obsidian";
+import ApiError from "../apiError";
 
 export default class ImagekitUploader implements ImageUploader {
-    private readonly imagekit!: Imagekit;
     private readonly setting!: ImagekitSetting;
 
     constructor(setting: ImagekitSetting) {
-        this.imagekit = new Imagekit({
-            publicKey: setting.publicKey,
-            privateKey: setting.privateKey,
-            urlEndpoint: setting.endpoint,
-        });
         this.setting = setting;
     }
+
     async upload(image: File, fullPath: string): Promise<string> {
-        const result = await this.imagekit.upload({
-            file : Buffer.from((await image.arrayBuffer())).toString('base64'),   //required
-            fileName : image.name,   //required
-            folder: this.setting.folder || '/',
-            extensions: [
-                {
-                    name: "google-auto-tagging",
-                    maxTags: 5,
-                    minConfidence: 95
-                }
-            ]
+        // Use Obsidian's requestUrl instead of the imagekit SDK.
+        // The SDK uses Node.js native HTTP which conflicts with Obsidian's Electron sandbox,
+        // causing AsyncResource wild pointer access → SIGSEGV crash on upload.
+        const arrayBuffer = await image.arrayBuffer();
+        const base64 = Buffer.from(arrayBuffer).toString("base64");
+        const mimeType = image.type || "application/octet-stream";
+        const fileData = `data:${mimeType};base64,${base64}`;
+        const authHeader =
+            "Basic " + Buffer.from(this.setting.privateKey + ":").toString("base64");
+
+        const boundary = "----ObsidianImageKit" + Date.now().toString(36);
+        const fields: Record<string, string> = {
+            file: fileData,
+            fileName: image.name,
+        };
+
+        if (this.setting.folder?.trim()) {
+            fields.folder = this.setting.folder.trim();
+        }
+
+        let body = "";
+        for (const [key, value] of Object.entries(fields)) {
+            body += `--${boundary}\r\n`;
+            body += `Content-Disposition: form-data; name="${key}"\r\n\r\n`;
+            body += `${value}\r\n`;
+        }
+        body += `--${boundary}--\r\n`;
+
+        const response = await requestUrl({
+            url: "https://upload.imagekit.io/api/v1/files/upload",
+            method: "POST",
+            headers: {
+                Authorization: authHeader,
+                "Content-Type": `multipart/form-data; boundary=${boundary}`,
+            },
+            body: body,
         });
 
-        return result.url;
+        if (response.status !== 200) {
+            const errMsg = response.json?.message || response.text;
+            throw new ApiError(`ImageKit upload failed (${response.status}): ${errMsg}`);
+        }
+
+        return response.json.url;
     }
 }
-
 
 export interface ImagekitSetting {
     folder: string;


### PR DESCRIPTION
## why this PR

使用 imagekit 上传图片时，在触发 `Image Upload Toolkit: Publish Page` 之后，Obsidian 会出现白屏。

## Design

根据崩溃日志分析（见 PR 中 `dev-docs` 里文档），通过使用 Obsidian 自身的 `requestUrl` 方法规避。

### Others

开发过程中发现 esbuild 版本过低，无法在 M1 芯片的 Mac 上运行，故升级。