### PR TITLE
feat: two optimizations for web image process

### DIFF
--- a/src/uploader/imageTagProcessor.ts
+++ b/src/uploader/imageTagProcessor.ts
@@ -7,8 +7,7 @@ import {WebImageDownloader} from "./webImageDownloader";
 import MermaidProcessor from "./mermaidProcessor";
 import ImageStore from "../imageStore";
 
-export const MD_REGEX = /\!\[(.*)\]\((.*?\.(png|jpg|jpeg|gif|svg|webp|excalidraw))\)/g;
-export const OPEN_MD_REGEX = /\!\[([^\]]*)\]\(([^)]*)\)/g;
+export const MD_REGEX = /\!\[([^\]]*)\]\(([^)]*)\)/g;
 export const WIKI_REGEX = /\!\[\[(.*?\.(png|jpg|jpeg|gif|svg|webp|excalidraw))(|.*)?\]\]/g;
 export const PROPERTIES_REGEX = /^---[\s\S]+?---\n/;
 
@@ -265,7 +264,7 @@ export default class ImageTagProcessor {
                 this.processMatched(match[1], match[0], images);
             }
             
-            const mdMatches = value.matchAll(OPEN_MD_REGEX);
+            const mdMatches = value.matchAll(MD_REGEX);
             for (const match of mdMatches) {
                 const imageUrl = match[2];
                 
@@ -279,6 +278,11 @@ export default class ImageTagProcessor {
                     continue;
                 }
                 
+                const localPath = imageUrl.split('?')[0];
+                if (!/\.(png|jpg|jpeg|gif|svg|webp|excalidraw)$/i.test(localPath)) {
+                    continue;
+                }
+
                 const decodedName = decodeURI(imageUrl);
                 this.processMatched(decodedName, match[0], images);
             }

--- a/src/uploader/imageTagProcessor.ts
+++ b/src/uploader/imageTagProcessor.ts
@@ -8,6 +8,7 @@ import MermaidProcessor from "./mermaidProcessor";
 import ImageStore from "../imageStore";
 
 export const MD_REGEX = /\!\[(.*)\]\((.*?\.(png|jpg|jpeg|gif|svg|webp|excalidraw))\)/g;
+export const OPEN_MD_REGEX = /\!\[([^\]]*)\]\(([^)]*)/g;
 export const WIKI_REGEX = /\!\[\[(.*?\.(png|jpg|jpeg|gif|svg|webp|excalidraw))(|.*)?\]\]/g;
 export const PROPERTIES_REGEX = /^---[\s\S]+?---\n/;
 
@@ -264,7 +265,7 @@ export default class ImageTagProcessor {
                 this.processMatched(match[1], match[0], images);
             }
             
-            const mdMatches = value.matchAll(MD_REGEX);
+            const mdMatches = value.matchAll(OPEN_MD_REGEX);
             for (const match of mdMatches) {
                 const imageUrl = match[2];
                 

--- a/src/uploader/imageTagProcessor.ts
+++ b/src/uploader/imageTagProcessor.ts
@@ -278,6 +278,7 @@ export default class ImageTagProcessor {
                     continue;
                 }
                 
+                // Skip non-image local files (e.g., .pdf, .txt) to prevent invalid uploads
                 const localPath = imageUrl.split('?')[0];
                 if (!/\.(png|jpg|jpeg|gif|svg|webp|excalidraw)$/i.test(localPath)) {
                     continue;

--- a/src/uploader/imageTagProcessor.ts
+++ b/src/uploader/imageTagProcessor.ts
@@ -8,7 +8,7 @@ import MermaidProcessor from "./mermaidProcessor";
 import ImageStore from "../imageStore";
 
 export const MD_REGEX = /\!\[(.*)\]\((.*?\.(png|jpg|jpeg|gif|svg|webp|excalidraw))\)/g;
-export const OPEN_MD_REGEX = /\!\[([^\]]*)\]\(([^)]*)/g;
+export const OPEN_MD_REGEX = /\!\[([^\]]*)\]\(([^)]*)\)/g;
 export const WIKI_REGEX = /\!\[\[(.*?\.(png|jpg|jpeg|gif|svg|webp|excalidraw))(|.*)?\]\]/g;
 export const PROPERTIES_REGEX = /^---[\s\S]+?---\n/;
 

--- a/src/uploader/webImageDownloader.ts
+++ b/src/uploader/webImageDownloader.ts
@@ -22,6 +22,7 @@ export function getExtensionFromContentType(contentType?: string): string {
 }
 
 export function extractFilename(url: string, contentType?: string): string {
+    const timestamp = Date.now() + "_" + Math.random().toString(36).slice(2);
     try {
         const urlObj = new URL(url);
         const pathname = urlObj.pathname;
@@ -31,13 +32,11 @@ export function extractFilename(url: string, contentType?: string): string {
         if (filename && /\.(png|jpg|jpeg|gif|svg|webp)$/i.test(filename)) {
             return decodeURIComponent(filename);
         }
-
         const extension = getExtensionFromContentType(contentType);
-        const timestamp = Date.now();
         return `web-image-${timestamp}${extension}`;
     } catch (error) {
         const extension = getExtensionFromContentType(contentType);
-        return `web-image-${Date.now()}${extension}`;
+        return `web-image-${timestamp}${extension}`;
     }
 }
 

--- a/tests/unit/imageTagRegex.test.ts
+++ b/tests/unit/imageTagRegex.test.ts
@@ -13,6 +13,7 @@ describe("MD_REGEX", () => {
     "![alt](image.webp)",
     "![alt](drawing.excalidraw)",
     "![alt](http://example.com/img.png)",
+    "![image](https://mmbiz.qpic.cn/mmbiz_svg/Q3auHgzwzM4xmCJEFEWXFbXXHia3ibH7U4RLVfQzuRjs2icgedowztV9fIB3Vsrrzt53YVkIGn2Q5dehvaWrUib8GaeHWAqYdzOJvBrxraoKfAicZBVw2wK8Htg/640?wx_fmt=svg&from=appmsg&tp=webp&wxfrom=5&wx_lazy=1#imgIndex=1)",
   ];
 
   const nonMatches = ["![alt](file.pdf)", "![alt](file.txt)"];
@@ -26,22 +27,29 @@ describe("MD_REGEX", () => {
     }
   });
 
-  it("does not match unsupported markdown image formats", () => {
+  it("matches markdown image syntax regardless of extension", () => {
     const regex = fresh(MD_REGEX);
 
     for (const input of nonMatches) {
-      expect(regex.test(input)).toBe(false);
+      expect(regex.test(input)).toBe(true);
       regex.lastIndex = 0;
     }
   });
 
-  it("captures alt full path and extension groups", () => {
+  it("captures alt and full path groups", () => {
     const regex = fresh(MD_REGEX);
     const match = regex.exec("![my alt](path/to/file.jpeg)");
 
     expect(match?.[1]).toBe("my alt");
     expect(match?.[2]).toBe("path/to/file.jpeg");
-    expect(match?.[3]).toBe("jpeg");
+  });
+
+  it("captures alt and url for web images without extension", () => {
+    const regex = fresh(MD_REGEX);
+    const match = regex.exec("![image](https://mmbiz.qpic.cn/mmbiz_svg/Q3auHgzwzM4xmCJEFEWXFbXXHia3ibH7U4RLVfQzuRjs2icgedowztV9fIB3Vsrrzt53YVkIGn2Q5dehvaWrUib8GaeHWAqYdzOJvBrxraoKfAicZBVw2wK8Htg/640?wx_fmt=svg&from=appmsg&tp=webp&wxfrom=5&wx_lazy=1#imgIndex=1)");
+
+    expect(match?.[1]).toBe("image");
+    expect(match?.[2]).toBe("https://mmbiz.qpic.cn/mmbiz_svg/Q3auHgzwzM4xmCJEFEWXFbXXHia3ibH7U4RLVfQzuRjs2icgedowztV9fIB3Vsrrzt53YVkIGn2Q5dehvaWrUib8GaeHWAqYdzOJvBrxraoKfAicZBVw2wK8Htg/640?wx_fmt=svg&from=appmsg&tp=webp&wxfrom=5&wx_lazy=1#imgIndex=1");
   });
 });
 

--- a/tests/unit/webImageDownloader.test.ts
+++ b/tests/unit/webImageDownloader.test.ts
@@ -35,21 +35,25 @@ describe("extractFilename", () => {
   it("generates png filename from content type when extension missing", () => {
     vi.spyOn(Date, "now").mockReturnValue(1710000000000);
 
-    expect(extractFilename("https://example.com/path/image", "image/png")).toBe(
-      "web-image-1710000000000.png",
+    expect(extractFilename("https://example.com/path/image", "image/png")).toMatch(
+      /^web-image-1710000000000_[a-z0-9]+\.png$/,
     );
   });
 
   it("generates jpg filename when extension and content type missing", () => {
     vi.spyOn(Date, "now").mockReturnValue(1710000000001);
 
-    expect(extractFilename("https://example.com/path/image")).toBe("web-image-1710000000001.jpg");
+    expect(extractFilename("https://example.com/path/image")).toMatch(
+      /^web-image-1710000000001_[a-z0-9]+\.jpg$/,
+    );
   });
 
   it("falls back to generated filename for invalid URL", () => {
     vi.spyOn(Date, "now").mockReturnValue(1710000000002);
 
-    expect(extractFilename("not-a-valid-url")).toBe("web-image-1710000000002.jpg");
+    expect(extractFilename("not-a-valid-url")).toMatch(
+      /^web-image-1710000000002_[a-z0-9]+\.jpg$/,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- feat: Add OPEN_MD_REGEX for matching markdown image syntax with more flexibility
- fix: Correct regex capture group for closing parenthesis
- refactor: Improve web image filename generation with enhanced uniqueness

## Changes

src/uploader/imageTagProcessor.ts

- Added exported OPEN_MD_REGEX pattern to match markdown images
- Replaced MD_REGEX with OPEN_MD_REGEX in the image processing logic for better compatibility

src/uploader/webImageDownloader.ts

- Optimized extractFilename() by extracting a combined timestamp variable using Date.now() + Math.random().toString(36)
- Ensures unique filenames even when multiple downloads occur in the same millisecond

## Motivation

The new OPEN_MD_REGEX provides better flexibility in matching markdown image syntax, while the filename generation improvement prevents potential collisions during concurrent web image downloads.

## Example

With the new regex, URLs like the following are correctly parsed:

```
https://mmbiz.qpic.cn/mmbiz_svg/Q3auHgzwzM4xmCJEFEWXFbXXHia3ibH7U4RLVfQzuRjs2icgedowztV9fIB3Vsrrzt53YVkIGn2Q5dehvaWrUib8GaeHWAqYdzOJvBrxraoKfAicZBVw2wK8Htg/640?wx_fmt=svg&from=appmsg&tp=webp&wxfrom=5&wx_lazy=1#imgIndex=1
```

## Acknowledgments

Thanks to @addozhang for creating and maintaining this project.