### PR TITLE
feat: support {ext} variable in target path

### DIFF
--- a/src/ui/publishSettingTab.ts
+++ b/src/ui/publishSettingTab.ts
@@ -285,7 +285,7 @@ export default class PublishSettingTab extends PluginSettingTab {
 
         new Setting(parentEL)
             .setName("Target Path")
-            .setDesc("The path to store image.\nSupport {year} {mon} {day} {random} {filename} vars. For example, /{year}/{mon}/{day}/{filename} with uploading pic.jpg, it will store as /2023/06/08/pic.jpg.")
+            .setDesc("The path to store image.\nSupport {year} {mon} {day} {random} {filename} {ext} vars. For example, /{year}/{mon}/{day}/{filename} with uploading pic.jpg, it will store as /2023/06/08/pic.jpg. Another example, /{random}.{ext} will store as /abc123def456.jpg.")
             .addText(text =>
                 text
                     .setPlaceholder("Enter path")
@@ -389,7 +389,7 @@ export default class PublishSettingTab extends PluginSettingTab {
                 .onChange(value => this.plugin.settings.awsS3Setting.bucketName = value));
         new Setting(parentEL)
             .setName("Target Path")
-            .setDesc("The path to store image.\nSupport {year} {mon} {day} {random} {filename} vars. For example, /{year}/{mon}/{day}/{filename} with uploading pic.jpg, it will store as /2023/06/08/pic.jpg.")
+            .setDesc("The path to store image.\nSupport {year} {mon} {day} {random} {filename} {ext} vars. For example, /{year}/{mon}/{day}/{filename} with uploading pic.jpg, it will store as /2023/06/08/pic.jpg. Another example, /{random}.{ext} will store as /abc123def456.jpg.")
             .addText(text =>
                 text
                     .setPlaceholder("Enter path")
@@ -446,7 +446,7 @@ export default class PublishSettingTab extends PluginSettingTab {
 
         new Setting(parentEL)
             .setName("Target Path")
-            .setDesc("The path to store image.\nSupport {year} {mon} {day} {random} {filename} vars. For example, /{year}/{mon}/{day}/{filename} with uploading pic.jpg, it will store as /2023/06/08/pic.jpg.")
+            .setDesc("The path to store image.\nSupport {year} {mon} {day} {random} {filename} {ext} vars. For example, /{year}/{mon}/{day}/{filename} with uploading pic.jpg, it will store as /2023/06/08/pic.jpg. Another example, /{random}.{ext} will store as /abc123def456.jpg.")
             .addText(text =>
                 text
                     .setPlaceholder("Enter path")
@@ -492,7 +492,7 @@ export default class PublishSettingTab extends PluginSettingTab {
 
         // new Setting(parentEL)
         //     .setName("Target Path")
-        //     .setDesc("The path to store image.\nSupport {year} {mon} {day} {random} {filename} vars. For example, /{year}/{mon}/{day}/{filename} with uploading pic.jpg, it will store as /2023/06/08/pic.jpg.")
+        //     .setDesc("The path to store image.\nSupport {year} {mon} {day} {random} {filename} {ext} vars. For example, /{year}/{mon}/{day}/{filename} with uploading pic.jpg, it will store as /2023/06/08/pic.jpg. Another example, /{random}.{ext} will store as /abc123def456.jpg.")
         //     .addText(text =>
         //         text
         //             .setPlaceholder("Enter path")
@@ -599,7 +599,7 @@ export default class PublishSettingTab extends PluginSettingTab {
 
         new Setting(parentEL)
             .setName("Target Path")
-            .setDesc("The path to store image.\nSupport {year} {mon} {day} {random} {filename} vars. For example, /{year}/{mon}/{day}/{filename} with uploading pic.jpg, it will store as /2023/06/08/pic.jpg.")
+            .setDesc("The path to store image.\nSupport {year} {mon} {day} {random} {filename} {ext} vars. For example, /{year}/{mon}/{day}/{filename} with uploading pic.jpg, it will store as /2023/06/08/pic.jpg. Another example, /{random}.{ext} will store as /abc123def456.jpg.")
             .addText(text =>
                 text
                     .setPlaceholder("Enter path")
@@ -653,7 +653,7 @@ export default class PublishSettingTab extends PluginSettingTab {
 
         new Setting(parentEL)
             .setName("Target Path")
-            .setDesc("The path to store image.\nSupport {year} {mon} {day} {random} {filename} vars. For example, /{year}/{mon}/{day}/{filename} with uploading pic.jpg, it will store as /2023/06/08/pic.jpg.")
+            .setDesc("The path to store image.\nSupport {year} {mon} {day} {random} {filename} {ext} vars. For example, /{year}/{mon}/{day}/{filename} with uploading pic.jpg, it will store as /2023/06/08/pic.jpg. Another example, /{random}.{ext} will store as /abc123def456.jpg.")
             .addText(text =>
                 text
                     .setPlaceholder("Enter path")

--- a/src/uploader/uploaderUtils.ts
+++ b/src/uploader/uploaderUtils.ts
@@ -7,6 +7,7 @@ export class UploaderUtils {
         const month = (date.getMonth() + 1).toString().padStart(2, '0');
         const day = date.getDate().toString().padStart(2, '0');
         const random = this.generateRandomString(20);
+        const ext = path.extname(imageName).replace(/^\./, '');
 
         return pathTmpl != undefined && pathTmpl.trim().length > 0 ? pathTmpl
                 .replace('{year}', year)
@@ -14,6 +15,7 @@ export class UploaderUtils {
                 .replace('{day}', day)
                 .replace('{random}', random)
                 .replace('{filename}', imageName)
+                .replace('{ext}', ext)
             : imageName
             ;
     }

--- a/tests/unit/uploaderUtils.test.ts
+++ b/tests/unit/uploaderUtils.test.ts
@@ -30,6 +30,30 @@ describe("UploaderUtils.generateName", () => {
     expect(result).toBe("uploads/photo.jpg");
   });
 
+  it("replaces ext variable with extension without dot", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+
+    const result = UploaderUtils.generateName("{random}.{ext}", "photo.jpg");
+
+    expect(result).toBe("A".repeat(20) + ".jpg");
+  });
+
+  it("replaces ext for different file types", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+
+    expect(UploaderUtils.generateName("uploads/{filename}.{ext}", "image.png")).toBe("uploads/image.png.png");
+    expect(UploaderUtils.generateName("uploads/{filename}.{ext}", "image.webp")).toBe("uploads/image.webp.webp");
+    expect(UploaderUtils.generateName("uploads/{filename}.{ext}", "image.JPEG")).toBe("uploads/image.JPEG.JPEG");
+  });
+
+  it("replaces ext with no extension in filename", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+
+    const result = UploaderUtils.generateName("uploads/{random}.{ext}", "noextension");
+
+    expect(result).toBe("uploads/" + "A".repeat(20) + ".");
+  });
+
   it("replaces all variables together", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2024-01-17T08:00:00.000Z"));


### PR DESCRIPTION
Add support for the `{ext}` placeholder in the target path template, allowing users to dynamically include the file extension in the generated filename.

- Update `UploaderUtils.generateName` to extract and replace `{ext}`.
- Update `PublishSettingTab` UI descriptions to include the new variable.
- Add unit tests for `{ext}` replacement in various scenarios.