### PR TITLE
Compliance batch 2: DOM correctness (multi-window APIs, innerHTML removal)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,13 @@ export default tseslint.config(
 			globals: {
 				...globals.browser,
 				...globals.node,
+				// Obsidian augments window/document with multi-window helpers.
+				activeWindow: "readonly",
+				activeDocument: "readonly",
+				createFragment: "readonly",
+				createEl: "readonly",
+				createDiv: "readonly",
+				createSpan: "readonly",
 			},
 			parserOptions: {
 				projectService: {
@@ -60,12 +67,12 @@ export default tseslint.config(
 		},
 	},
 	{
-		// Tracked for the DOM-correctness batch (innerHTML refactor).
+		// no-inner-html resolved in Batch 2 (mermaidProcessor uses DOMParser).
 		plugins: {
 			"@microsoft/sdl": sdl,
 		},
 		rules: {
-			"@microsoft/sdl/no-inner-html": "warn",
+			"@microsoft/sdl/no-inner-html": "error",
 		},
 	},
 	globalIgnores([

--- a/src/ui/publishSettingTab.ts
+++ b/src/ui/publishSettingTab.ts
@@ -190,14 +190,11 @@ export default class PublishSettingTab extends PluginSettingTab {
     }
 
     private static clientIdSettingDescription() {
-        const fragment = document.createDocumentFragment();
-        const a = document.createElement("a");
         const url = "https://api.imgur.com/oauth2/addclient";
-        a.textContent = url;
-        a.setAttribute("href", url);
-        fragment.append("Generate your own Client ID at ");
-        fragment.append(a);
-        return fragment;
+        return createFragment(frag => {
+            frag.append("Generate your own Client ID at ");
+            frag.createEl("a", { text: url, href: url });
+        });
     }
 
     private drawGyazoSetting(parentEL: HTMLDivElement) {
@@ -234,14 +231,11 @@ export default class PublishSettingTab extends PluginSettingTab {
     }
 
     private static gyazoTokenSettingDescription() {
-        const fragment = document.createDocumentFragment();
-        const a = document.createElement("a");
         const url = "https://gyazo.com/oauth/applications";
-        a.textContent = url;
-        a.setAttribute("href", url);
-        fragment.append("Create an application and issue an access token at ");
-        fragment.append(a);
-        return fragment;
+        return createFragment(frag => {
+            frag.append("Create an application and issue an access token at ");
+            frag.createEl("a", { text: url, href: url });
+        });
     }
 
     // Aliyun OSS Setting
@@ -343,14 +337,11 @@ export default class PublishSettingTab extends PluginSettingTab {
     }
 
     private static imagekitSettingDescription() {
-        const fragment = document.createDocumentFragment();
-        const a = document.createElement("a");
         const url = "https://imagekit.io/dashboard/developer/api-keys";
-        a.textContent = url;
-        a.setAttribute("href", url);
-        fragment.append("Obtain id and keys from ");
-        fragment.append(a);
-        return fragment;
+        return createFragment(frag => {
+            frag.append("Obtain id and keys from ");
+            frag.createEl("a", { text: url, href: url });
+        });
     }
 
     private drawAwsS3Setting(parentEL: HTMLDivElement) {
@@ -553,14 +544,11 @@ export default class PublishSettingTab extends PluginSettingTab {
     }
 
     private static githubTokenDescription() {
-        const fragment = document.createDocumentFragment();
-        const a = document.createElement("a");
         const url = "https://github.com/settings/tokens";
-        a.textContent = url;
-        a.setAttribute("href", url);
-        fragment.append("Generate a personal access token with 'repo' scope at ");
-        fragment.append(a);
-        return fragment;
+        return createFragment(frag => {
+            frag.append("Generate a personal access token with 'repo' scope at ");
+            frag.createEl("a", { text: url, href: url });
+        });
     }
 
     private drawR2Setting(parentEL: HTMLDivElement) {

--- a/src/ui/uploadProgressModal.ts
+++ b/src/ui/uploadProgressModal.ts
@@ -8,10 +8,19 @@ export default class UploadProgressModal extends Modal {
     private imageListEl: HTMLElement;
     private statusEl: HTMLElement;
     private imageStatus: Map<string, boolean> = new Map();
-    
+    private autoCloseTimer: number | null = null;
+
     constructor(app) {
         super(app);
         this.titleEl.setText("Uploading Images");
+    }
+
+    onClose(): void {
+        if (this.autoCloseTimer !== null) {
+            activeWindow.clearTimeout(this.autoCloseTimer);
+            this.autoCloseTimer = null;
+        }
+        super.onClose?.();
     }
     
     /**
@@ -98,7 +107,8 @@ export default class UploadProgressModal extends Modal {
             this.statusEl.createSpan({text: "Complete", cls: "status-text"});
             
             // Auto-close after 3 seconds
-            setTimeout(() => {
+            this.autoCloseTimer = activeWindow.setTimeout(() => {
+                this.autoCloseTimer = null;
                 this.close();
             }, 3000);
         }
@@ -153,7 +163,7 @@ export default class UploadProgressModal extends Modal {
         
         // Progress bar container styling
         const progressBarContainer = modalContent.querySelector(".progress-bar-container");
-        if (progressBarContainer instanceof HTMLElement) {
+        if (progressBarContainer instanceof activeWindow.HTMLElement) {
             progressBarContainer.style.width = "100%";
             progressBarContainer.style.height = "8px";
             progressBarContainer.style.backgroundColor = "var(--background-modifier-border)";
@@ -163,14 +173,14 @@ export default class UploadProgressModal extends Modal {
         
         // Progress section styling
         const progressSection = modalContent.querySelector(".progress-section");
-        if (progressSection instanceof HTMLElement) {
+        if (progressSection instanceof activeWindow.HTMLElement) {
             progressSection.style.marginBottom = "20px";
             progressSection.style.textAlign = "center";
         }
         
         // Image list styling
         const imageList = modalContent.querySelector(".image-list");
-        if (imageList instanceof HTMLElement) {
+        if (imageList instanceof activeWindow.HTMLElement) {
             imageList.style.maxHeight = "200px";
             imageList.style.overflowY = "auto";
             imageList.style.border = "1px solid var(--background-modifier-border)";

--- a/src/uploader/mermaidProcessor.ts
+++ b/src/uploader/mermaidProcessor.ts
@@ -71,8 +71,8 @@ export default class MermaidProcessor {
                 new Notice(msg, 8000);
                 value = value.replace(match[0], `<!-- mermaid render failed: block ${i + 1} -->`);
             } finally {
-                document.getElementById(id)?.remove();
-                document.getElementById(`d${id}`)?.remove();
+                activeDocument.getElementById(id)?.remove();
+                activeDocument.getElementById(`d${id}`)?.remove();
             }
         }
         return { value, generatedUrls };
@@ -97,7 +97,7 @@ export default class MermaidProcessor {
                     canvasHeight = Math.floor(canvasHeight * downscale);
                 }
 
-                const canvas = document.createElement("canvas");
+                const canvas = activeDocument.createElement("canvas");
                 canvas.width = canvasWidth;
                 canvas.height = canvasHeight;
                 const ctx = canvas.getContext("2d");
@@ -118,14 +118,14 @@ export default class MermaidProcessor {
     /**
      * Sanitize mermaid SVG for safe loading via <img> data URI.
      *
-     * Uses innerHTML (lenient HTML parser) instead of DOMParser (strict XML parser)
-     * because mermaid CSS contains unescaped quotes/selectors that break XML parsing.
-     * XMLSerializer then outputs valid XML with proper escaping.
+     * Parses via DOMParser in HTML mode (lenient like innerHTML) rather than
+     * XML mode, because mermaid CSS contains unescaped quotes/selectors that
+     * break the strict XML parser. The resulting SVG is then re-serialized
+     * as valid XML by XMLSerializer with proper escaping.
      */
     private sanitizeSvg(svgString: string): string {
-        const container = document.createElement("div");
-        container.innerHTML = svgString;
-        const svgEl = container.querySelector("svg");
+        const parsed = new DOMParser().parseFromString(svgString, "text/html");
+        const svgEl = parsed.querySelector("svg");
         if (!svgEl) return svgString;
 
         this.replaceForeignObjects(svgEl);
@@ -138,6 +138,7 @@ export default class MermaidProcessor {
 
     private replaceForeignObjects(svgEl: SVGSVGElement): void {
         const SVG_NS = "http://www.w3.org/2000/svg";
+        const ownerDoc = svgEl.ownerDocument;
         svgEl.querySelectorAll("foreignObject").forEach(fo => {
             const x = parseFloat(fo.getAttribute("x") || "0");
             const y = parseFloat(fo.getAttribute("y") || "0");
@@ -148,12 +149,12 @@ export default class MermaidProcessor {
             if (lines.length === 0) { fo.remove(); return; }
 
             const styledEl = fo.querySelector("span, div, p");
-            const computed = styledEl ? window.getComputedStyle(styledEl) : null;
+            const computed = styledEl ? activeWindow.getComputedStyle(styledEl) : null;
             const fontSize = parseFloat(computed?.fontSize || "14");
             const fontFamily = computed?.fontFamily || "sans-serif";
             const fill = computed?.color || "#333";
 
-            const textEl = document.createElementNS(SVG_NS, "text");
+            const textEl = ownerDoc.createElementNS(SVG_NS, "text");
             textEl.setAttribute("text-anchor", "middle");
             textEl.setAttribute("font-size", String(fontSize));
             textEl.setAttribute("font-family", fontFamily);
@@ -171,7 +172,7 @@ export default class MermaidProcessor {
                 const totalTextHeight = lineHeight * lines.length;
                 const startY = y + (height - totalTextHeight) / 2 + fontSize;
                 for (let i = 0; i < lines.length; i++) {
-                    const tspan = document.createElementNS(SVG_NS, "tspan");
+                    const tspan = ownerDoc.createElementNS(SVG_NS, "tspan");
                     tspan.setAttribute("x", String(centerX));
                     tspan.setAttribute("y", String(startY + i * lineHeight));
                     tspan.textContent = lines[i];


### PR DESCRIPTION
## Summary

Resolves the DOM-correctness violations flagged by the Obsidian Portal scorecard so the plugin works correctly in popout windows and no longer triggers the `innerHTML` risk warning.

### Changes

- **`mermaidProcessor.ts`**
  - Replace `innerHTML`-based SVG parsing with `new DOMParser().parseFromString(svgString, "text/html")`. Same lenient parsing behavior as `innerHTML` (mermaid's CSS still parses), without the security-rule violation. Re-serialization via `XMLSerializer` is unchanged.
  - Replace `document.` / `window.` with `activeDocument.` / `activeWindow.` so cleanup and computed-style lookups work in popout windows.
  - Use `svgEl.ownerDocument.createElementNS` for new SVG nodes so they belong to the parsed document.

- **`uploadProgressModal.ts`**
  - Register the auto-close timer as a tracked `activeWindow.setTimeout` handle and clear it in `onClose()`, preventing leaked timers if the user dismisses the modal early.
  - Replace `instanceof HTMLElement` with `instanceof activeWindow.HTMLElement` (popout windows have their own HTMLElement constructor).

- **`publishSettingTab.ts`**
  - Replace four `document.createDocumentFragment()` + `document.createElement("a")` blocks with Obsidian's `createFragment(frag => frag.createEl("a", { text, href }))` builder.

- **`eslint.config.mjs`**
  - Register Obsidian runtime globals (`activeWindow`, `activeDocument`, `createFragment`, `createEl`, `createDiv`, `createSpan`) so `no-undef` recognizes them.
  - Promote `@microsoft/sdl/no-inner-html` back to `error` now that the single occurrence is resolved.

### Verification

- `npx eslint .` — 0 errors, 232 warnings (down from 13 errors, 232 warnings during refactor).
- `npm test` — 71/71 pass.
- `npm run build` — succeeds (16 MB; bundle size addressed in Batch 4).

### Scope notes

- 17 inline-style assignments in `uploadProgressModal.addStyles()` remain (Batch 3, CSS extraction).
- 76 sentence-case UI-copy warnings remain (separate UI-copy batch).
- Promise hygiene and bundle-size work remain in Batches 4 and 5.