### PR TITLE
Compliance batch 3: 行内样式迁移到 styles.css

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -62,8 +62,8 @@ export default tseslint.config(
 		rules: {
 			// Sentence-case fixes are tracked separately as a UI-copy pass.
 			"obsidianmd/ui/sentence-case": "warn",
-			// Inline-style refactor is tracked separately.
-			"obsidianmd/no-static-styles-assignment": "warn",
+			// no-static-styles-assignment resolved in Batch 3 (styles moved to styles.css).
+			"obsidianmd/no-static-styles-assignment": "error",
 		},
 	},
 	{

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,3 +1,81 @@
 /*
-* Add any styles you want to be included w/ your plugin here
-*/
+ * obsidian-image-upload-toolkit
+ * Styles for plugin-owned UI surfaces. Use CSS variables exposed by Obsidian
+ * (--interactive-accent, --background-modifier-border, etc.) so the plugin
+ * inherits the active theme.
+ */
+
+/* Upload progress modal */
+.upload-progress-modal .upload-progress-content {
+    padding: 4px 0;
+}
+
+.upload-progress-modal .progress-section {
+    margin-bottom: 20px;
+    text-align: center;
+}
+
+.upload-progress-modal .status-indicator {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 8px;
+}
+
+.upload-progress-modal .progress-bar-container {
+    width: 100%;
+    height: 8px;
+    background-color: var(--background-modifier-border);
+    border-radius: 4px;
+    margin-bottom: 10px;
+    overflow: hidden;
+}
+
+.upload-progress-modal .progress-bar {
+    width: 0;
+    height: 8px;
+    background-color: var(--interactive-accent);
+    border-radius: 4px;
+    transition: width 0.3s ease-in-out;
+}
+
+.upload-progress-modal .progress-text {
+    font-size: var(--font-ui-small);
+    color: var(--text-muted);
+}
+
+.upload-progress-modal .image-list-container {
+    margin-top: 12px;
+}
+
+.upload-progress-modal .image-list-heading {
+    font-weight: var(--font-semibold);
+    margin-bottom: 6px;
+}
+
+.upload-progress-modal .image-list {
+    max-height: 200px;
+    overflow-y: auto;
+    border: 1px solid var(--background-modifier-border);
+    border-radius: 4px;
+    padding: 8px;
+}
+
+.upload-progress-modal .image-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 2px 0;
+}
+
+.upload-progress-modal .image-status-icon.success {
+    color: var(--interactive-success, var(--color-green));
+}
+
+.upload-progress-modal .image-status-icon.pending {
+    color: var(--text-muted);
+}
+
+.upload-progress-modal .image-name {
+    font-size: var(--font-ui-small);
+}

--- a/src/ui/uploadProgressModal.ts
+++ b/src/ui/uploadProgressModal.ts
@@ -66,13 +66,10 @@ export default class UploadProgressModal extends Modal {
         // Image list (if we have image names)
         if (this.imageStatus.size > 0) {
             const imageListContainer = contentEl.createDiv({cls: "image-list-container"});
-            imageListContainer.createEl("h3", {text: "Images"});
+            imageListContainer.createDiv({cls: "image-list-heading", text: "Images"});
             this.imageListEl = imageListContainer.createDiv({cls: "image-list"});
             this.renderImageList();
         }
-        
-        // Style the modal
-        this.addStyles();
     }
     
     /**
@@ -145,47 +142,6 @@ export default class UploadProgressModal extends Modal {
             
             // Image name
             itemEl.createSpan({text: name, cls: "image-name"});
-        }
-    }
-    
-    /**
-     * Add custom styles to the modal
-     */
-    private addStyles(): void {
-        // Add custom styles to the progress bar
-        this.progressBarEl.style.width = "0%";
-        this.progressBarEl.style.height = "8px";
-        this.progressBarEl.style.backgroundColor = "var(--interactive-accent)";
-        this.progressBarEl.style.borderRadius = "4px";
-        this.progressBarEl.style.transition = "width 0.3s ease-in-out";
-        
-        const modalContent = this.contentEl;
-        
-        // Progress bar container styling
-        const progressBarContainer = modalContent.querySelector(".progress-bar-container");
-        if (progressBarContainer instanceof activeWindow.HTMLElement) {
-            progressBarContainer.style.width = "100%";
-            progressBarContainer.style.height = "8px";
-            progressBarContainer.style.backgroundColor = "var(--background-modifier-border)";
-            progressBarContainer.style.borderRadius = "4px";
-            progressBarContainer.style.marginBottom = "10px";
-        }
-        
-        // Progress section styling
-        const progressSection = modalContent.querySelector(".progress-section");
-        if (progressSection instanceof activeWindow.HTMLElement) {
-            progressSection.style.marginBottom = "20px";
-            progressSection.style.textAlign = "center";
-        }
-        
-        // Image list styling
-        const imageList = modalContent.querySelector(".image-list");
-        if (imageList instanceof activeWindow.HTMLElement) {
-            imageList.style.maxHeight = "200px";
-            imageList.style.overflowY = "auto";
-            imageList.style.border = "1px solid var(--background-modifier-border)";
-            imageList.style.borderRadius = "4px";
-            imageList.style.padding = "8px";
         }
     }
 }


### PR DESCRIPTION
## Summary

依 Obsidian UI 指南，把 `UploadProgressModal` 17 处行内样式抽取到 `src/styles.css`，并移除模态框里的 `<h3>` 标题。

### Changes

- **`src/ui/uploadProgressModal.ts`**
  - 删除整个 `addStyles()` 方法及其调用，所有静态属性（颜色、高度、边框、过渡、padding、overflow 等）迁到 CSS。
  - `imageListContainer.createEl("h3")` → `createDiv({cls: "image-list-heading"})`，避免在文档大纲里插入插件标题级别。
  - `progressBarEl.style.width = '${percent}%'` 保留在 `updateProgress()` —— 动态计算值，Obsidian 政策允许。

- **`src/styles.css`**
  - 新增 BEM 风格规则集，全部 scoped 在 `.upload-progress-modal` 下。
  - 使用 Obsidian CSS 变量（`--interactive-accent`、`--background-modifier-border`、`--text-muted`、`--font-ui-small`、`--font-semibold`）继承当前主题。

- **`eslint.config.mjs`**
  - `obsidianmd/no-static-styles-assignment` 从 `warn` 提升为 `error`。

### Verification

- `npx eslint .` — 0 errors, 203 warnings（从 232 降到 203，消减 29 条）。
- `npm test` — 71/71 通过。
- `npm run build` — 成功。
- release workflow 已经会上传 `src/styles.css`（Batch 1 已配置）。

### Base

基于 `compliance/batch-2-dom-correctness`（PR #60）。请在 PR #60 合并后再合本 PR；GitHub 会自动把 base 改为 `main`。