### PR TITLE
Compliance batch 5: Promise 卫生

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -48,11 +48,11 @@ export default tseslint.config(
 			"@typescript-eslint/no-unsafe-return": "warn",
 			"@typescript-eslint/no-unsafe-argument": "warn",
 			"@typescript-eslint/no-require-imports": "warn",
-			// Tracked for a later batch (promise hygiene refactor).
-			"@typescript-eslint/no-floating-promises": "warn",
-			"@typescript-eslint/no-misused-promises": "warn",
-			"@typescript-eslint/await-thenable": "warn",
-			"no-async-promise-executor": "warn",
+			// Promise hygiene re-enabled as error in Batch 5.
+			"@typescript-eslint/no-floating-promises": "error",
+			"@typescript-eslint/no-misused-promises": "error",
+			"@typescript-eslint/await-thenable": "error",
+			"no-async-promise-executor": "error",
 		},
 	},
 	{

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -165,7 +165,9 @@ export default class ObsidianPublish extends Plugin {
         if (!this.imageUploader) {
             new Notice("Image uploader setup failed, please check setting.")
         } else {
-            this.imageTagProcessor.process(ACTION_PUBLISH).then(() => {
+            this.imageTagProcessor.process(ACTION_PUBLISH).catch(err => {
+                console.error("Image upload toolkit: publish failed", err);
+                new Notice(`Publish failed: ${err?.message || err}`, 8000);
             });
         }
     }

--- a/src/ui/publishSettingTab.ts
+++ b/src/ui/publishSettingTab.ts
@@ -103,7 +103,7 @@ export default class PublishSettingTab extends PluginSettingTab {
                     "neutral": "Neutral",
                     "base": "Base",
                 };
-                Object.entries(themes).forEach(([value, label]) => dd.addOption(value, label));
+                Object.entries(themes).forEach(([value, label]) => { dd.addOption(value, label); });
                 dd.setValue(this.plugin.settings.mermaidTheme);
                 dd.onChange(value => this.plugin.settings.mermaidTheme = value);
             });
@@ -128,12 +128,15 @@ export default class PublishSettingTab extends PluginSettingTab {
                     await this.drawImageStoreSettings(this.imageStoreDiv);
                 });
             });
-        this.drawImageStoreSettings(this.imageStoreDiv);
+        void this.drawImageStoreSettings(this.imageStoreDiv);
     }
 
-    async hide(): Promise<unknown> {
-        await this.plugin.saveSettings();
-        this.plugin.setupImageUploader();
+    hide(): void {
+        void this.plugin.saveSettings().then(() => {
+            this.plugin.setupImageUploader();
+        }).catch(err => {
+            console.error("Image upload toolkit: saveSettings failed", err);
+        });
     }
 
     private async drawImageStoreSettings(parentEL: HTMLDivElement) {

--- a/src/uploader/imageTagProcessor.ts
+++ b/src/uploader/imageTagProcessor.ts
@@ -120,7 +120,7 @@ export default class ImageTagProcessor {
         for (const image of images) {
             // Handle web images differently
             if (image.isWebImage) {
-                promises.push(new Promise<Image>(async (resolve, reject) => {
+                promises.push((async (): Promise<Image> => {
                     try {
                         // Download the web image
                         const downloadResult = await WebImageDownloader.download(image.path);
@@ -135,7 +135,7 @@ export default class ImageTagProcessor {
                         if (this.progressModal) {
                             this.progressModal.updateProgress(image.name, true);
                         }
-                        resolve(image);
+                        return image;
                     } catch (e) {
                         // Update progress on failed upload
                         if (this.progressModal) {
@@ -144,9 +144,9 @@ export default class ImageTagProcessor {
                         const errorMessage = `Upload web image ${image.path} failed: ${e.error || e.message || e}`;
                         new Notice(errorMessage, 10000);
                         console.error('Web image upload error:', e);
-                        reject(new Error(errorMessage));
+                        throw new Error(errorMessage);
                     }
-                }));
+                })());
                 continue;
             }
             
@@ -247,7 +247,7 @@ export default class ImageTagProcessor {
 
         switch (action) {
             case ACTION_PUBLISH:
-                navigator.clipboard.writeText(value);
+                await navigator.clipboard.writeText(value);
                 new Notice("Copied to clipboard");
                 break;
             default:

--- a/src/uploader/imgur/imgurAnonymousUploader.ts
+++ b/src/uploader/imgur/imgurAnonymousUploader.ts
@@ -20,10 +20,10 @@ export default class ImgurAnonymousUploader implements ImageUploader {
             method: "POST",
             url: `${IMGUR_API_BASE}image`})
 
-        if ((await resp).status != 200) {
-            await handleImgurErrorResponse(resp);
+        if (resp.status != 200) {
+            handleImgurErrorResponse(resp);
         }
-        return ((await resp.json) as ImgurPostData).data.link;
+        return (resp.json as ImgurPostData).data.link;
     }
 }
 
@@ -31,9 +31,9 @@ export interface ImgurAnonymousSetting {
     clientId: string;
 }
 
-export async function handleImgurErrorResponse(resp: RequestUrlResponse): Promise<void> {
-    if ((await resp).headers["Content-Type"] === "application/json") {
-        throw new ApiError(((await resp.json) as ImgurErrorData).data.error);
+export function handleImgurErrorResponse(resp: RequestUrlResponse): void {
+    if (resp.headers["Content-Type"] === "application/json") {
+        throw new ApiError((resp.json as ImgurErrorData).data.error);
     }
     throw new Error(resp.text);
 }


### PR DESCRIPTION
## Summary

修复 ESLint 报出的所有 Promise 相关问题（9 处），并把对应规则从 `warn` 升为 `error`。

### Changes

- **`publish.ts:164`** `publish()` 现在 `.catch` 异常，通过 `Notice` 显示给用户，不再静默吞错。

- **`ui/publishSettingTab.ts`**
  - `hide()` 改为同步返回 `void`（父类 `PluginSettingTab.hide()` 签名是 void）；`saveSettings()` 改用 `.then(setupImageUploader).catch(console.error)` 链式调用。
  - `drawImageStoreSettings()` 调用前加 `void` 标记意图上的 fire-and-forget。
  - 把 `Object.entries(themes).forEach(([v,l]) => dd.addOption(v,l))` 加大括号包成语句，丢弃返回值。

- **`uploader/imageTagProcessor.ts`**
  - 用 async IIFE 替换 `new Promise(async (resolve, reject) => …)` 反模式（123 行）。
  - 给 `navigator.clipboard.writeText()` 加 `await`（250 行），失败时正常向上抛。

- **`uploader/imgur/imgurAnonymousUploader.ts`**
  - 移除 `await` 已 await 过的 `RequestUrlResponse` 字段（`.status`、`.json`、`.headers`）。
  - `handleImgurErrorResponse()` 改为同步（原本就没有异步操作，只是 throw）。

- **`eslint.config.mjs`** 升级：
  - `@typescript-eslint/no-floating-promises` → error
  - `@typescript-eslint/no-misused-promises` → error
  - `@typescript-eslint/await-thenable` → error
  - `no-async-promise-executor` → error

### Verification

- `npx eslint .` — 0 errors, 195 warnings（从 203 降到 195，promise 类全清零）。
- `npm test` — 71/71 通过。
- `npm run build` — 成功。

### Base

基于 `compliance/batch-3-inline-styles-to-css`（PR #61）。合并顺序：#60 → #61 → 本 PR。