### PR TITLE
Compliance batch 4: migrate aws-sdk v2 to v3 modular client

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,0 +1,29 @@
+import esbuild from "esbuild";
+import {copyFile, mkdir} from "node:fs/promises";
+
+const prod = process.argv.includes("--prod") || process.env.NODE_ENV === "production";
+const watch = process.argv.includes("--watch");
+
+const context = await esbuild.context({
+  entryPoints: ["src/publish.ts"],
+  bundle: true,
+  platform: "node",
+  format: "cjs",
+  target: "es2022",
+  mainFields: ["browser", "module", "main"],
+  external: ["obsidian", "electron"],
+  outfile: "dist/main.js",
+  sourcemap: prod ? false : "inline",
+  minify: prod,
+  logLevel: "info",
+});
+
+await mkdir("dist", {recursive: true});
+await copyFile("manifest.json", "dist/manifest.json");
+
+if (watch) {
+  await context.watch();
+} else {
+  await context.rebuild();
+  await context.dispose();
+}

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "main": "main.js",
   "license": "MIT",
   "scripts": {
-    "build": "obsidian-plugin build src/publish.ts",
-    "dev": "obsidian-plugin dev src/publish.ts",
+    "build": "node esbuild.config.mjs --prod",
+    "dev": "node esbuild.config.mjs --watch",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "test": "vitest run",
@@ -26,15 +26,14 @@
     "jiti": "^2.6.1",
     "jsdom": "^29.0.0",
     "obsidian": "obsidianmd/obsidian-api",
-    "obsidian-plugin-cli": "^0.4.3",
     "typescript": "^4.0.3",
     "typescript-eslint": "^8.35.1",
     "vitest": "^4.1.0"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1048.0",
     "@octokit/rest": "^19.0.4",
     "ali-oss": "^6.17.1",
-    "aws-sdk": "^2.1664.0",
     "cos-nodejs-sdk-v5": "^2.14.6",
     "imagekit": "^5.0.0",
     "proxy-agent": "^5.0.0",

--- a/src/uploader/b2/b2Uploader.ts
+++ b/src/uploader/b2/b2Uploader.ts
@@ -1,5 +1,5 @@
 import ImageUploader from "../imageUploader";
-import AWS from 'aws-sdk';
+import {PutObjectCommand, S3Client} from "@aws-sdk/client-s3";
 import {UploaderUtils} from "../uploaderUtils";
 
 const EXTENSION_MIME_MAP: Record<string, string> = {
@@ -12,19 +12,20 @@ const EXTENSION_MIME_MAP: Record<string, string> = {
 };
 
 export default class B2Uploader implements ImageUploader {
-  private readonly s3!: AWS.S3;
+  private readonly s3!: S3Client;
   private readonly bucket!: string;
   private pathTmpl: string;
   private customDomainName: string;
 
   constructor(setting: B2Setting) {
-    this.s3 = new AWS.S3({
-      accessKeyId: setting.accessKeyId,
-      secretAccessKey: setting.secretAccessKey,
+    this.s3 = new S3Client({
+      credentials: {
+        accessKeyId: setting.accessKeyId,
+        secretAccessKey: setting.secretAccessKey,
+      },
       endpoint: `https://s3.${setting.region}.backblazeb2.com`,
       region: setting.region,
-      s3ForcePathStyle: true,
-      signatureVersion: 'v4',
+      forcePathStyle: true,
     });
     this.bucket = setting.bucketName;
     this.pathTmpl = setting.path;
@@ -32,36 +33,19 @@ export default class B2Uploader implements ImageUploader {
   }
 
   async upload(image: File, fullPath: string): Promise<string> {
-    const arrayBuffer = await this.readFileAsArrayBuffer(image);
+    const arrayBuffer = await image.arrayBuffer();
     const uint8Array = new Uint8Array(arrayBuffer);
     let path = UploaderUtils.generateName(this.pathTmpl, image.name);
     path = path.replace(/^\/+/, ''); // remove the /
     const ext = image.name.split('.').pop()?.toLowerCase() ?? '';
     const contentType = image.type || EXTENSION_MIME_MAP[ext] || `image/${ext}`;
-    const params = {
+    await this.s3.send(new PutObjectCommand({
       Bucket: this.bucket,
       Key: path,
       Body: uint8Array,
       ContentType: contentType,
-    };
-    return new Promise((resolve, reject) => {
-      this.s3.upload(params, (err, data) => {
-        if (err) {
-          reject(err instanceof Error ? err : new Error(String(err)));
-        } else {
-          resolve(UploaderUtils.customizeDomainName(data.Key, this.customDomainName));
-        }
-      });
-    });
-  }
-
-  private readFileAsArrayBuffer(file: File): Promise<ArrayBuffer> {
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onload = () => resolve(reader.result as ArrayBuffer);
-      reader.onerror = reject;
-      reader.readAsArrayBuffer(file);
-    });
+    }));
+    return UploaderUtils.customizeDomainName(path, this.customDomainName);
   }
 }
 

--- a/src/uploader/r2/r2Uploader.ts
+++ b/src/uploader/r2/r2Uploader.ts
@@ -1,21 +1,22 @@
 import ImageUploader from "../imageUploader";
-import AWS from 'aws-sdk';
+import {PutObjectCommand, S3Client} from "@aws-sdk/client-s3";
 import {UploaderUtils} from "../uploaderUtils";
 
 export default class R2Uploader implements ImageUploader {
-  private readonly r2!: AWS.S3;
+  private readonly r2!: S3Client;
   private readonly bucket!: string;
   private pathTmpl: string;
   private customDomainName: string;
 
   constructor(setting: R2Setting) {
-    this.r2 = new AWS.S3({
-      accessKeyId: setting.accessKeyId,
-      secretAccessKey: setting.secretAccessKey,
+    this.r2 = new S3Client({
+      credentials: {
+        accessKeyId: setting.accessKeyId,
+        secretAccessKey: setting.secretAccessKey,
+      },
       endpoint: setting.endpoint,
       region: 'auto', // Cloudflare R2 uses 'auto' region
-      s3ForcePathStyle: true, // Needed for Cloudflare R2
-      signatureVersion: 'v4', // Cloudflare R2 uses v4 signatures
+      forcePathStyle: true, // Needed for Cloudflare R2
     });
     this.bucket = setting.bucketName;
     this.pathTmpl = setting.path;
@@ -23,35 +24,17 @@ export default class R2Uploader implements ImageUploader {
   }
 
   async upload(image: File, fullPath: string): Promise<string> {
-    const arrayBuffer = await this.readFileAsArrayBuffer(image);
+    const arrayBuffer = await image.arrayBuffer();
     const uint8Array = new Uint8Array(arrayBuffer);
     let path = UploaderUtils.generateName(this.pathTmpl, image.name);
     path = path.replace(/^\/+/, ''); // remove the /
-    const params = {
+    await this.r2.send(new PutObjectCommand({
       Bucket: this.bucket,
       Key: path,
       Body: uint8Array,
       ContentType: `image/${image.name.split('.').pop()}`,
-    };
-    return new Promise((resolve, reject) => {
-      this.r2.upload(params, (err, data) => {
-        if (err) {
-          reject(err instanceof Error ? err : new Error(String(err)));
-        } else {
-          const dst = data.Location.split(`/${this.bucket}/`).pop();
-          resolve(UploaderUtils.customizeDomainName(dst, this.customDomainName));
-        }
-      });
-    });
-  }
-
-  private readFileAsArrayBuffer(file: File): Promise<ArrayBuffer> {
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onload = () => resolve(reader.result as ArrayBuffer);
-      reader.onerror = reject;
-      reader.readAsArrayBuffer(file);
-    });
+    }));
+    return UploaderUtils.customizeDomainName(path, this.customDomainName);
   }
 }
 

--- a/src/uploader/s3/awsS3Uploader.ts
+++ b/src/uploader/s3/awsS3Uploader.ts
@@ -1,53 +1,41 @@
 import ImageUploader from "../imageUploader";
-import AWS from 'aws-sdk';
+import {PutObjectCommand, S3Client} from "@aws-sdk/client-s3";
 import {UploaderUtils} from "../uploaderUtils";
 
 export default class AwsS3Uploader implements ImageUploader {
-  private readonly s3!: AWS.S3;
+  private readonly s3!: S3Client;
   private readonly bucket!: string;
+  private readonly region: string;
   private pathTmpl: string;
   private customDomainName: string;
 
 
   constructor(setting: AwsS3Setting) {
-    this.s3 = new AWS.S3({
-      accessKeyId: setting.accessKeyId,
-      secretAccessKey: setting.secretAccessKey,
-      region: setting.region
+    this.s3 = new S3Client({
+      credentials: {
+        accessKeyId: setting.accessKeyId,
+        secretAccessKey: setting.secretAccessKey,
+      },
+      region: setting.region,
     });
     this.bucket = setting.bucketName;
+    this.region = setting.region;
     this.pathTmpl = setting.path;
     this.customDomainName = setting.customDomainName;
   }
 
   async upload(image: File, fullPath: string): Promise<string> {
-    const arrayBuffer = await this.readFileAsArrayBuffer(image);
+    const arrayBuffer = await image.arrayBuffer();
     const uint8Array = new Uint8Array(arrayBuffer);
     let path = UploaderUtils.generateName(this.pathTmpl, image.name);
     path = path.replace(/^\/+/, ''); // remove the /
-    const params = {
+    await this.s3.send(new PutObjectCommand({
       Bucket: this.bucket,
       Key: path,
       Body: uint8Array,
-    };
-    return new Promise((resolve, reject) => {
-      this.s3.upload(params, (err, data) => {
-        if (err) {
-          reject(err instanceof Error ? err : new Error(String(err)));
-        } else {
-          resolve(UploaderUtils.customizeDomainName(data.Location, this.customDomainName));
-        }
-      });
-    });
-  }
-
-  private readFileAsArrayBuffer(file: File): Promise<ArrayBuffer> {
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onload = () => resolve(reader.result as ArrayBuffer);
-      reader.onerror = reject;
-      reader.readAsArrayBuffer(file);
-    });
+    }));
+    const location = `https://${this.bucket}.s3.${this.region}.amazonaws.com/${path}`;
+    return UploaderUtils.customizeDomainName(location, this.customDomainName);
   }
 }
 export interface AwsS3Setting {


### PR DESCRIPTION
## Why

Bundle weight at the start of this batch was **16 MB**, well above the 5 MB Obsidian Sync cap and unusually large for a community plugin. Three uploaders (S3, R2, B2) pulled in the monolithic `aws-sdk` v2 package (100 MB on disk), which v2's namespace-import shape prevents esbuild from tree-shaking. `aws-sdk` v2 also reaches end-of-life September 2025.

## Changes

- Replace `aws-sdk` v2 with `@aws-sdk/client-s3` v3 modular client in `awsS3Uploader.ts`, `r2Uploader.ts`, `b2Uploader.ts`. Each uploader now uses `PutObjectCommand` via `S3Client.send()`.
- Drop per-uploader `readFileAsArrayBuffer` helpers in favour of the standard `File.arrayBuffer()` method already used elsewhere in the codebase.
- R2: derive returned URL from the bucket key directly instead of parsing v2's `data.Location` string (v3 does not return Location for `PutObject`; the bucket+key path is what `customizeDomainName` consumes anyway).
- Replace `obsidian-plugin-cli` (ships esbuild 0.8, predates `node:` protocol support and chokes on v3's `node:fs` imports) with a small `esbuild.config.mjs` using the project's own esbuild 0.18. Externals, format, and platform match the previous configuration; `target` set to `es2022` to accommodate BigInt literals in transitive deps.

## Result

| Metric | Before | After |
| --- | --- | --- |
| `dist/main.js` | 16 MB | **7.2 MB** (-55%) |
| `node_modules/aws-sdk` on disk | 100 MB | removed |
| `node_modules/@aws-sdk` on disk | 0 | 12 MB |

- Lint: 0 errors / 188 warnings (was 195).
- Tests: 71/71 pass.
- No public API changes; uploader interfaces, settings, and behaviour preserved.

## Follow-ups

- Bundle is still above 5 MB Sync cap; further reductions possible by replacing `ali-oss` (3.4 MB) and `cos-nodejs-sdk-v5` (444 KB) with direct `requestUrl` calls plus inline signing. Tracked as a future batch.

## Stack

Based on `compliance/batch-5-promise-hygiene` (PR #62). GitHub will auto-retarget to `main` as ancestor PRs merge.