### PR TITLE
Compliance batch 4c: replace qiniu SDK with requestUrl + inline signing

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,0 +1,29 @@
+import esbuild from "esbuild";
+import {copyFile, mkdir} from "node:fs/promises";
+
+const prod = process.argv.includes("--prod") || process.env.NODE_ENV === "production";
+const watch = process.argv.includes("--watch");
+
+const context = await esbuild.context({
+  entryPoints: ["src/publish.ts"],
+  bundle: true,
+  platform: "node",
+  format: "cjs",
+  target: "es2022",
+  mainFields: ["browser", "module", "main"],
+  external: ["obsidian", "electron"],
+  outfile: "dist/main.js",
+  sourcemap: prod ? false : "inline",
+  minify: prod,
+  logLevel: "info",
+});
+
+await mkdir("dist", {recursive: true});
+await copyFile("manifest.json", "dist/manifest.json");
+
+if (watch) {
+  await context.watch();
+} else {
+  await context.rebuild();
+  await context.dispose();
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -48,11 +48,11 @@ export default tseslint.config(
 			"@typescript-eslint/no-unsafe-return": "warn",
 			"@typescript-eslint/no-unsafe-argument": "warn",
 			"@typescript-eslint/no-require-imports": "warn",
-			// Tracked for a later batch (promise hygiene refactor).
-			"@typescript-eslint/no-floating-promises": "warn",
-			"@typescript-eslint/no-misused-promises": "warn",
-			"@typescript-eslint/await-thenable": "warn",
-			"no-async-promise-executor": "warn",
+			// Promise hygiene re-enabled as error in Batch 5.
+			"@typescript-eslint/no-floating-promises": "error",
+			"@typescript-eslint/no-misused-promises": "error",
+			"@typescript-eslint/await-thenable": "error",
+			"no-async-promise-executor": "error",
 		},
 	},
 	{

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,13 @@ export default tseslint.config(
 			globals: {
 				...globals.browser,
 				...globals.node,
+				// Obsidian augments window/document with multi-window helpers.
+				activeWindow: "readonly",
+				activeDocument: "readonly",
+				createFragment: "readonly",
+				createEl: "readonly",
+				createDiv: "readonly",
+				createSpan: "readonly",
 			},
 			parserOptions: {
 				projectService: {
@@ -60,12 +67,12 @@ export default tseslint.config(
 		},
 	},
 	{
-		// Tracked for the DOM-correctness batch (innerHTML refactor).
+		// no-inner-html resolved in Batch 2 (mermaidProcessor uses DOMParser).
 		plugins: {
 			"@microsoft/sdl": sdl,
 		},
 		rules: {
-			"@microsoft/sdl/no-inner-html": "warn",
+			"@microsoft/sdl/no-inner-html": "error",
 		},
 	},
 	globalIgnores([

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -62,8 +62,8 @@ export default tseslint.config(
 		rules: {
 			// Sentence-case fixes are tracked separately as a UI-copy pass.
 			"obsidianmd/ui/sentence-case": "warn",
-			// Inline-style refactor is tracked separately.
-			"obsidianmd/no-static-styles-assignment": "warn",
+			// no-static-styles-assignment resolved in Batch 3 (styles moved to styles.css).
+			"obsidianmd/no-static-styles-assignment": "error",
 		},
 	},
 	{

--- a/package.json
+++ b/package.json
@@ -33,10 +33,8 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1048.0",
     "@octokit/rest": "^19.0.4",
-    "ali-oss": "^6.17.1",
     "cos-nodejs-sdk-v5": "^2.14.6",
     "imagekit": "^5.0.0",
-    "proxy-agent": "^5.0.0",
     "qiniu": "^7.14.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@aws-sdk/client-s3": "^3.1048.0",
     "@octokit/rest": "^19.0.4",
     "cos-nodejs-sdk-v5": "^2.14.6",
-    "imagekit": "^5.0.0",
-    "qiniu": "^7.14.0"
+    "imagekit": "^5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "main": "main.js",
   "license": "MIT",
   "scripts": {
-    "build": "obsidian-plugin build src/publish.ts",
-    "dev": "obsidian-plugin dev src/publish.ts",
+    "build": "node esbuild.config.mjs --prod",
+    "dev": "node esbuild.config.mjs --watch",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "test": "vitest run",
@@ -26,15 +26,14 @@
     "jiti": "^2.6.1",
     "jsdom": "^29.0.0",
     "obsidian": "obsidianmd/obsidian-api",
-    "obsidian-plugin-cli": "^0.4.3",
     "typescript": "^4.0.3",
     "typescript-eslint": "^8.35.1",
     "vitest": "^4.1.0"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1048.0",
     "@octokit/rest": "^19.0.4",
     "ali-oss": "^6.17.1",
-    "aws-sdk": "^2.1664.0",
     "cos-nodejs-sdk-v5": "^2.14.6",
     "imagekit": "^5.0.0",
     "proxy-agent": "^5.0.0",

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -165,7 +165,9 @@ export default class ObsidianPublish extends Plugin {
         if (!this.imageUploader) {
             new Notice("Image uploader setup failed, please check setting.")
         } else {
-            this.imageTagProcessor.process(ACTION_PUBLISH).then(() => {
+            this.imageTagProcessor.process(ACTION_PUBLISH).catch(err => {
+                console.error("Image upload toolkit: publish failed", err);
+                new Notice(`Publish failed: ${err?.message || err}`, 8000);
             });
         }
     }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,3 +1,81 @@
 /*
-* Add any styles you want to be included w/ your plugin here
-*/
+ * obsidian-image-upload-toolkit
+ * Styles for plugin-owned UI surfaces. Use CSS variables exposed by Obsidian
+ * (--interactive-accent, --background-modifier-border, etc.) so the plugin
+ * inherits the active theme.
+ */
+
+/* Upload progress modal */
+.upload-progress-modal .upload-progress-content {
+    padding: 4px 0;
+}
+
+.upload-progress-modal .progress-section {
+    margin-bottom: 20px;
+    text-align: center;
+}
+
+.upload-progress-modal .status-indicator {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 8px;
+}
+
+.upload-progress-modal .progress-bar-container {
+    width: 100%;
+    height: 8px;
+    background-color: var(--background-modifier-border);
+    border-radius: 4px;
+    margin-bottom: 10px;
+    overflow: hidden;
+}
+
+.upload-progress-modal .progress-bar {
+    width: 0;
+    height: 8px;
+    background-color: var(--interactive-accent);
+    border-radius: 4px;
+    transition: width 0.3s ease-in-out;
+}
+
+.upload-progress-modal .progress-text {
+    font-size: var(--font-ui-small);
+    color: var(--text-muted);
+}
+
+.upload-progress-modal .image-list-container {
+    margin-top: 12px;
+}
+
+.upload-progress-modal .image-list-heading {
+    font-weight: var(--font-semibold);
+    margin-bottom: 6px;
+}
+
+.upload-progress-modal .image-list {
+    max-height: 200px;
+    overflow-y: auto;
+    border: 1px solid var(--background-modifier-border);
+    border-radius: 4px;
+    padding: 8px;
+}
+
+.upload-progress-modal .image-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 2px 0;
+}
+
+.upload-progress-modal .image-status-icon.success {
+    color: var(--interactive-success, var(--color-green));
+}
+
+.upload-progress-modal .image-status-icon.pending {
+    color: var(--text-muted);
+}
+
+.upload-progress-modal .image-name {
+    font-size: var(--font-ui-small);
+}

--- a/src/ui/publishSettingTab.ts
+++ b/src/ui/publishSettingTab.ts
@@ -103,7 +103,7 @@ export default class PublishSettingTab extends PluginSettingTab {
                     "neutral": "Neutral",
                     "base": "Base",
                 };
-                Object.entries(themes).forEach(([value, label]) => dd.addOption(value, label));
+                Object.entries(themes).forEach(([value, label]) => { dd.addOption(value, label); });
                 dd.setValue(this.plugin.settings.mermaidTheme);
                 dd.onChange(value => this.plugin.settings.mermaidTheme = value);
             });
@@ -128,12 +128,15 @@ export default class PublishSettingTab extends PluginSettingTab {
                     await this.drawImageStoreSettings(this.imageStoreDiv);
                 });
             });
-        this.drawImageStoreSettings(this.imageStoreDiv);
+        void this.drawImageStoreSettings(this.imageStoreDiv);
     }
 
-    async hide(): Promise<unknown> {
-        await this.plugin.saveSettings();
-        this.plugin.setupImageUploader();
+    hide(): void {
+        void this.plugin.saveSettings().then(() => {
+            this.plugin.setupImageUploader();
+        }).catch(err => {
+            console.error("Image upload toolkit: saveSettings failed", err);
+        });
     }
 
     private async drawImageStoreSettings(parentEL: HTMLDivElement) {

--- a/src/ui/publishSettingTab.ts
+++ b/src/ui/publishSettingTab.ts
@@ -190,14 +190,11 @@ export default class PublishSettingTab extends PluginSettingTab {
     }
 
     private static clientIdSettingDescription() {
-        const fragment = document.createDocumentFragment();
-        const a = document.createElement("a");
         const url = "https://api.imgur.com/oauth2/addclient";
-        a.textContent = url;
-        a.setAttribute("href", url);
-        fragment.append("Generate your own Client ID at ");
-        fragment.append(a);
-        return fragment;
+        return createFragment(frag => {
+            frag.append("Generate your own Client ID at ");
+            frag.createEl("a", { text: url, href: url });
+        });
     }
 
     private drawGyazoSetting(parentEL: HTMLDivElement) {
@@ -234,14 +231,11 @@ export default class PublishSettingTab extends PluginSettingTab {
     }
 
     private static gyazoTokenSettingDescription() {
-        const fragment = document.createDocumentFragment();
-        const a = document.createElement("a");
         const url = "https://gyazo.com/oauth/applications";
-        a.textContent = url;
-        a.setAttribute("href", url);
-        fragment.append("Create an application and issue an access token at ");
-        fragment.append(a);
-        return fragment;
+        return createFragment(frag => {
+            frag.append("Create an application and issue an access token at ");
+            frag.createEl("a", { text: url, href: url });
+        });
     }
 
     // Aliyun OSS Setting
@@ -343,14 +337,11 @@ export default class PublishSettingTab extends PluginSettingTab {
     }
 
     private static imagekitSettingDescription() {
-        const fragment = document.createDocumentFragment();
-        const a = document.createElement("a");
         const url = "https://imagekit.io/dashboard/developer/api-keys";
-        a.textContent = url;
-        a.setAttribute("href", url);
-        fragment.append("Obtain id and keys from ");
-        fragment.append(a);
-        return fragment;
+        return createFragment(frag => {
+            frag.append("Obtain id and keys from ");
+            frag.createEl("a", { text: url, href: url });
+        });
     }
 
     private drawAwsS3Setting(parentEL: HTMLDivElement) {
@@ -553,14 +544,11 @@ export default class PublishSettingTab extends PluginSettingTab {
     }
 
     private static githubTokenDescription() {
-        const fragment = document.createDocumentFragment();
-        const a = document.createElement("a");
         const url = "https://github.com/settings/tokens";
-        a.textContent = url;
-        a.setAttribute("href", url);
-        fragment.append("Generate a personal access token with 'repo' scope at ");
-        fragment.append(a);
-        return fragment;
+        return createFragment(frag => {
+            frag.append("Generate a personal access token with 'repo' scope at ");
+            frag.createEl("a", { text: url, href: url });
+        });
     }
 
     private drawR2Setting(parentEL: HTMLDivElement) {

--- a/src/ui/uploadProgressModal.ts
+++ b/src/ui/uploadProgressModal.ts
@@ -8,10 +8,19 @@ export default class UploadProgressModal extends Modal {
     private imageListEl: HTMLElement;
     private statusEl: HTMLElement;
     private imageStatus: Map<string, boolean> = new Map();
-    
+    private autoCloseTimer: number | null = null;
+
     constructor(app) {
         super(app);
         this.titleEl.setText("Uploading Images");
+    }
+
+    onClose(): void {
+        if (this.autoCloseTimer !== null) {
+            activeWindow.clearTimeout(this.autoCloseTimer);
+            this.autoCloseTimer = null;
+        }
+        super.onClose?.();
     }
     
     /**
@@ -98,7 +107,8 @@ export default class UploadProgressModal extends Modal {
             this.statusEl.createSpan({text: "Complete", cls: "status-text"});
             
             // Auto-close after 3 seconds
-            setTimeout(() => {
+            this.autoCloseTimer = activeWindow.setTimeout(() => {
+                this.autoCloseTimer = null;
                 this.close();
             }, 3000);
         }
@@ -153,7 +163,7 @@ export default class UploadProgressModal extends Modal {
         
         // Progress bar container styling
         const progressBarContainer = modalContent.querySelector(".progress-bar-container");
-        if (progressBarContainer instanceof HTMLElement) {
+        if (progressBarContainer instanceof activeWindow.HTMLElement) {
             progressBarContainer.style.width = "100%";
             progressBarContainer.style.height = "8px";
             progressBarContainer.style.backgroundColor = "var(--background-modifier-border)";
@@ -163,14 +173,14 @@ export default class UploadProgressModal extends Modal {
         
         // Progress section styling
         const progressSection = modalContent.querySelector(".progress-section");
-        if (progressSection instanceof HTMLElement) {
+        if (progressSection instanceof activeWindow.HTMLElement) {
             progressSection.style.marginBottom = "20px";
             progressSection.style.textAlign = "center";
         }
         
         // Image list styling
         const imageList = modalContent.querySelector(".image-list");
-        if (imageList instanceof HTMLElement) {
+        if (imageList instanceof activeWindow.HTMLElement) {
             imageList.style.maxHeight = "200px";
             imageList.style.overflowY = "auto";
             imageList.style.border = "1px solid var(--background-modifier-border)";

--- a/src/ui/uploadProgressModal.ts
+++ b/src/ui/uploadProgressModal.ts
@@ -66,13 +66,10 @@ export default class UploadProgressModal extends Modal {
         // Image list (if we have image names)
         if (this.imageStatus.size > 0) {
             const imageListContainer = contentEl.createDiv({cls: "image-list-container"});
-            imageListContainer.createEl("h3", {text: "Images"});
+            imageListContainer.createDiv({cls: "image-list-heading", text: "Images"});
             this.imageListEl = imageListContainer.createDiv({cls: "image-list"});
             this.renderImageList();
         }
-        
-        // Style the modal
-        this.addStyles();
     }
     
     /**
@@ -145,47 +142,6 @@ export default class UploadProgressModal extends Modal {
             
             // Image name
             itemEl.createSpan({text: name, cls: "image-name"});
-        }
-    }
-    
-    /**
-     * Add custom styles to the modal
-     */
-    private addStyles(): void {
-        // Add custom styles to the progress bar
-        this.progressBarEl.style.width = "0%";
-        this.progressBarEl.style.height = "8px";
-        this.progressBarEl.style.backgroundColor = "var(--interactive-accent)";
-        this.progressBarEl.style.borderRadius = "4px";
-        this.progressBarEl.style.transition = "width 0.3s ease-in-out";
-        
-        const modalContent = this.contentEl;
-        
-        // Progress bar container styling
-        const progressBarContainer = modalContent.querySelector(".progress-bar-container");
-        if (progressBarContainer instanceof activeWindow.HTMLElement) {
-            progressBarContainer.style.width = "100%";
-            progressBarContainer.style.height = "8px";
-            progressBarContainer.style.backgroundColor = "var(--background-modifier-border)";
-            progressBarContainer.style.borderRadius = "4px";
-            progressBarContainer.style.marginBottom = "10px";
-        }
-        
-        // Progress section styling
-        const progressSection = modalContent.querySelector(".progress-section");
-        if (progressSection instanceof activeWindow.HTMLElement) {
-            progressSection.style.marginBottom = "20px";
-            progressSection.style.textAlign = "center";
-        }
-        
-        // Image list styling
-        const imageList = modalContent.querySelector(".image-list");
-        if (imageList instanceof activeWindow.HTMLElement) {
-            imageList.style.maxHeight = "200px";
-            imageList.style.overflowY = "auto";
-            imageList.style.border = "1px solid var(--background-modifier-border)";
-            imageList.style.borderRadius = "4px";
-            imageList.style.padding = "8px";
         }
     }
 }

--- a/src/uploader/b2/b2Uploader.ts
+++ b/src/uploader/b2/b2Uploader.ts
@@ -1,5 +1,5 @@
 import ImageUploader from "../imageUploader";
-import AWS from 'aws-sdk';
+import {PutObjectCommand, S3Client} from "@aws-sdk/client-s3";
 import {UploaderUtils} from "../uploaderUtils";
 
 const EXTENSION_MIME_MAP: Record<string, string> = {
@@ -12,19 +12,20 @@ const EXTENSION_MIME_MAP: Record<string, string> = {
 };
 
 export default class B2Uploader implements ImageUploader {
-  private readonly s3!: AWS.S3;
+  private readonly s3!: S3Client;
   private readonly bucket!: string;
   private pathTmpl: string;
   private customDomainName: string;
 
   constructor(setting: B2Setting) {
-    this.s3 = new AWS.S3({
-      accessKeyId: setting.accessKeyId,
-      secretAccessKey: setting.secretAccessKey,
+    this.s3 = new S3Client({
+      credentials: {
+        accessKeyId: setting.accessKeyId,
+        secretAccessKey: setting.secretAccessKey,
+      },
       endpoint: `https://s3.${setting.region}.backblazeb2.com`,
       region: setting.region,
-      s3ForcePathStyle: true,
-      signatureVersion: 'v4',
+      forcePathStyle: true,
     });
     this.bucket = setting.bucketName;
     this.pathTmpl = setting.path;
@@ -32,36 +33,19 @@ export default class B2Uploader implements ImageUploader {
   }
 
   async upload(image: File, fullPath: string): Promise<string> {
-    const arrayBuffer = await this.readFileAsArrayBuffer(image);
+    const arrayBuffer = await image.arrayBuffer();
     const uint8Array = new Uint8Array(arrayBuffer);
     let path = UploaderUtils.generateName(this.pathTmpl, image.name);
     path = path.replace(/^\/+/, ''); // remove the /
     const ext = image.name.split('.').pop()?.toLowerCase() ?? '';
     const contentType = image.type || EXTENSION_MIME_MAP[ext] || `image/${ext}`;
-    const params = {
+    await this.s3.send(new PutObjectCommand({
       Bucket: this.bucket,
       Key: path,
       Body: uint8Array,
       ContentType: contentType,
-    };
-    return new Promise((resolve, reject) => {
-      this.s3.upload(params, (err, data) => {
-        if (err) {
-          reject(err instanceof Error ? err : new Error(String(err)));
-        } else {
-          resolve(UploaderUtils.customizeDomainName(data.Key, this.customDomainName));
-        }
-      });
-    });
-  }
-
-  private readFileAsArrayBuffer(file: File): Promise<ArrayBuffer> {
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onload = () => resolve(reader.result as ArrayBuffer);
-      reader.onerror = reject;
-      reader.readAsArrayBuffer(file);
-    });
+    }));
+    return UploaderUtils.customizeDomainName(path, this.customDomainName);
   }
 }
 

--- a/src/uploader/imageTagProcessor.ts
+++ b/src/uploader/imageTagProcessor.ts
@@ -120,7 +120,7 @@ export default class ImageTagProcessor {
         for (const image of images) {
             // Handle web images differently
             if (image.isWebImage) {
-                promises.push(new Promise<Image>(async (resolve, reject) => {
+                promises.push((async (): Promise<Image> => {
                     try {
                         // Download the web image
                         const downloadResult = await WebImageDownloader.download(image.path);
@@ -135,7 +135,7 @@ export default class ImageTagProcessor {
                         if (this.progressModal) {
                             this.progressModal.updateProgress(image.name, true);
                         }
-                        resolve(image);
+                        return image;
                     } catch (e) {
                         // Update progress on failed upload
                         if (this.progressModal) {
@@ -144,9 +144,9 @@ export default class ImageTagProcessor {
                         const errorMessage = `Upload web image ${image.path} failed: ${e.error || e.message || e}`;
                         new Notice(errorMessage, 10000);
                         console.error('Web image upload error:', e);
-                        reject(new Error(errorMessage));
+                        throw new Error(errorMessage);
                     }
-                }));
+                })());
                 continue;
             }
             
@@ -247,7 +247,7 @@ export default class ImageTagProcessor {
 
         switch (action) {
             case ACTION_PUBLISH:
-                navigator.clipboard.writeText(value);
+                await navigator.clipboard.writeText(value);
                 new Notice("Copied to clipboard");
                 break;
             default:

--- a/src/uploader/imgur/imgurAnonymousUploader.ts
+++ b/src/uploader/imgur/imgurAnonymousUploader.ts
@@ -20,10 +20,10 @@ export default class ImgurAnonymousUploader implements ImageUploader {
             method: "POST",
             url: `${IMGUR_API_BASE}image`})
 
-        if ((await resp).status != 200) {
-            await handleImgurErrorResponse(resp);
+        if (resp.status != 200) {
+            handleImgurErrorResponse(resp);
         }
-        return ((await resp.json) as ImgurPostData).data.link;
+        return (resp.json as ImgurPostData).data.link;
     }
 }
 
@@ -31,9 +31,9 @@ export interface ImgurAnonymousSetting {
     clientId: string;
 }
 
-export async function handleImgurErrorResponse(resp: RequestUrlResponse): Promise<void> {
-    if ((await resp).headers["Content-Type"] === "application/json") {
-        throw new ApiError(((await resp.json) as ImgurErrorData).data.error);
+export function handleImgurErrorResponse(resp: RequestUrlResponse): void {
+    if (resp.headers["Content-Type"] === "application/json") {
+        throw new ApiError((resp.json as ImgurErrorData).data.error);
     }
     throw new Error(resp.text);
 }

--- a/src/uploader/mermaidProcessor.ts
+++ b/src/uploader/mermaidProcessor.ts
@@ -71,8 +71,8 @@ export default class MermaidProcessor {
                 new Notice(msg, 8000);
                 value = value.replace(match[0], `<!-- mermaid render failed: block ${i + 1} -->`);
             } finally {
-                document.getElementById(id)?.remove();
-                document.getElementById(`d${id}`)?.remove();
+                activeDocument.getElementById(id)?.remove();
+                activeDocument.getElementById(`d${id}`)?.remove();
             }
         }
         return { value, generatedUrls };
@@ -97,7 +97,7 @@ export default class MermaidProcessor {
                     canvasHeight = Math.floor(canvasHeight * downscale);
                 }
 
-                const canvas = document.createElement("canvas");
+                const canvas = activeDocument.createElement("canvas");
                 canvas.width = canvasWidth;
                 canvas.height = canvasHeight;
                 const ctx = canvas.getContext("2d");
@@ -118,14 +118,14 @@ export default class MermaidProcessor {
     /**
      * Sanitize mermaid SVG for safe loading via <img> data URI.
      *
-     * Uses innerHTML (lenient HTML parser) instead of DOMParser (strict XML parser)
-     * because mermaid CSS contains unescaped quotes/selectors that break XML parsing.
-     * XMLSerializer then outputs valid XML with proper escaping.
+     * Parses via DOMParser in HTML mode (lenient like innerHTML) rather than
+     * XML mode, because mermaid CSS contains unescaped quotes/selectors that
+     * break the strict XML parser. The resulting SVG is then re-serialized
+     * as valid XML by XMLSerializer with proper escaping.
      */
     private sanitizeSvg(svgString: string): string {
-        const container = document.createElement("div");
-        container.innerHTML = svgString;
-        const svgEl = container.querySelector("svg");
+        const parsed = new DOMParser().parseFromString(svgString, "text/html");
+        const svgEl = parsed.querySelector("svg");
         if (!svgEl) return svgString;
 
         this.replaceForeignObjects(svgEl);
@@ -138,6 +138,7 @@ export default class MermaidProcessor {
 
     private replaceForeignObjects(svgEl: SVGSVGElement): void {
         const SVG_NS = "http://www.w3.org/2000/svg";
+        const ownerDoc = svgEl.ownerDocument;
         svgEl.querySelectorAll("foreignObject").forEach(fo => {
             const x = parseFloat(fo.getAttribute("x") || "0");
             const y = parseFloat(fo.getAttribute("y") || "0");
@@ -148,12 +149,12 @@ export default class MermaidProcessor {
             if (lines.length === 0) { fo.remove(); return; }
 
             const styledEl = fo.querySelector("span, div, p");
-            const computed = styledEl ? window.getComputedStyle(styledEl) : null;
+            const computed = styledEl ? activeWindow.getComputedStyle(styledEl) : null;
             const fontSize = parseFloat(computed?.fontSize || "14");
             const fontFamily = computed?.fontFamily || "sans-serif";
             const fill = computed?.color || "#333";
 
-            const textEl = document.createElementNS(SVG_NS, "text");
+            const textEl = ownerDoc.createElementNS(SVG_NS, "text");
             textEl.setAttribute("text-anchor", "middle");
             textEl.setAttribute("font-size", String(fontSize));
             textEl.setAttribute("font-family", fontFamily);
@@ -171,7 +172,7 @@ export default class MermaidProcessor {
                 const totalTextHeight = lineHeight * lines.length;
                 const startY = y + (height - totalTextHeight) / 2 + fontSize;
                 for (let i = 0; i < lines.length; i++) {
-                    const tspan = document.createElementNS(SVG_NS, "tspan");
+                    const tspan = ownerDoc.createElementNS(SVG_NS, "tspan");
                     tspan.setAttribute("x", String(centerX));
                     tspan.setAttribute("y", String(startY + i * lineHeight));
                     tspan.textContent = lines[i];

--- a/src/uploader/oss/ossUploader.ts
+++ b/src/uploader/oss/ossUploader.ts
@@ -1,34 +1,79 @@
+import {requestUrl} from "obsidian";
+import {createHash, createHmac} from "crypto";
 import ImageUploader from "../imageUploader";
 import {UploaderUtils} from "../uploaderUtils";
-import OSS from "ali-oss"
+
+const EXTENSION_MIME_MAP: Record<string, string> = {
+    jpg: "image/jpeg",
+    jpeg: "image/jpeg",
+    png: "image/png",
+    gif: "image/gif",
+    svg: "image/svg+xml",
+    webp: "image/webp",
+    bmp: "image/bmp",
+};
 
 export default class OssUploader implements ImageUploader {
-    private readonly client!: OSS;
     private readonly pathTmpl: string;
     private readonly customDomainName: string;
+    private readonly region: string;
+    private readonly bucket: string;
+    private readonly accessKeyId: string;
+    private readonly accessKeySecret: string;
 
     constructor(setting: OssSetting) {
-        this.client = new OSS({
-            region: setting.region,
-            accessKeyId: setting.accessKeyId,
-            accessKeySecret: setting.accessKeySecret,
-            bucket: setting.bucket,
-            secure: true,
-        });
-        this.client.agent = this.client.urllib.agent;
-        this.client.httpsAgent = this.client.urllib.httpsAgent;
+        this.region = setting.region;
+        this.bucket = setting.bucket;
+        this.accessKeyId = setting.accessKeyId;
+        this.accessKeySecret = setting.accessKeySecret;
         this.pathTmpl = setting.path;
         this.customDomainName = setting.customDomainName;
     }
 
-    async upload(image: File, path: string): Promise<string> {
-        // Use the File object's buffer instead of reading from filesystem
-        // This allows uploading web images and local images uniformly
-        const buffer = await image.arrayBuffer();
-        const result = this.client.put(UploaderUtils.generateName(this.pathTmpl, image.name), Buffer.from(buffer));
-        return UploaderUtils.customizeDomainName((await result).url, this.customDomainName);
+    async upload(image: File, fullPath: string): Promise<string> {
+        const key = UploaderUtils.generateName(this.pathTmpl, image.name).replace(/^\/+/, "");
+        const body = await image.arrayBuffer();
+        const contentType = this.resolveContentType(image);
+        const contentMd5 = createHash("md5").update(Buffer.from(body)).digest("base64");
+        const date = new Date().toUTCString();
+
+        const stringToSign = [
+            "PUT",
+            contentMd5,
+            contentType,
+            date,
+            `/${this.bucket}/${key}`,
+        ].join("\n");
+        const signature = createHmac("sha1", this.accessKeySecret).update(stringToSign).digest("base64");
+
+        const url = `https://${this.bucket}.${this.region}.aliyuncs.com/${encodeURI(key)}`;
+        const response = await requestUrl({
+            url,
+            method: "PUT",
+            headers: {
+                Authorization: `OSS ${this.accessKeyId}:${signature}`,
+                "Content-Type": contentType,
+                "Content-MD5": contentMd5,
+                Date: date,
+            },
+            body,
+            throw: false,
+        });
+
+        if (response.status < 200 || response.status >= 300) {
+            throw new Error(`Aliyun OSS upload failed (${response.status}): ${response.text || "no response body"}`);
+        }
+
+        return UploaderUtils.customizeDomainName(url, this.customDomainName);
     }
 
+    private resolveContentType(image: File): string {
+        if (image.type) {
+            return image.type;
+        }
+        const ext = image.name.split(".").pop()?.toLowerCase() ?? "";
+        return EXTENSION_MIME_MAP[ext] || "application/octet-stream";
+    }
 }
 
 export interface OssSetting {

--- a/src/uploader/qiniu/kodoUploader.ts
+++ b/src/uploader/qiniu/kodoUploader.ts
@@ -1,6 +1,10 @@
+import {requestUrl} from "obsidian";
+import {createHmac} from "crypto";
 import ImageUploader from "../imageUploader";
-import qiniu from "qiniu";
 import {UploaderUtils} from "../uploaderUtils";
+
+const QINIU_UPLOAD_HOST = "https://upload.qiniup.com";
+const TOKEN_LIFETIME_SECONDS = 3600;
 
 export default class KodoUploader implements ImageUploader {
 
@@ -15,47 +19,80 @@ export default class KodoUploader implements ImageUploader {
     async upload(image: File, path: string): Promise<string> {
         //check custom domain name
         if (!this.setting.customDomainName || this.setting.customDomainName.trim() === "") {
-            throw new Error("Custom domain name is required for Qiniu Kodo.")
+            throw new Error("Custom domain name is required for Qiniu Kodo.");
         }
         this.updateToken();
-        const config = new qiniu.conf.Config();
-        const formUploader = new qiniu.form_up.FormUploader(config);
-        const putExtra = new qiniu.form_up.PutExtra();
-        let key = UploaderUtils.generateName(this.setting.path, image.name.replaceAll(' ', '_')); //replace space with _ in file name
-        
-        // Read file buffer instead of using filesystem path for better web image support
+        const key = UploaderUtils.generateName(this.setting.path, image.name.replaceAll(" ", "_"));
         const buffer = Buffer.from(await image.arrayBuffer());
-        
-        return formUploader
-            .put(this.uploadToken, key, buffer, putExtra)
-            .then(({data, resp}) => {
-                if (resp.statusCode === 200) {
-                    return this.setting.customDomainName + '/' + data.key;
-                } else {
-                    throw data;
-                }
-            })
-            .catch((err) => {
-                throw err
-            });
+
+        const boundary = `----ObsidianFormBoundary${Date.now().toString(16)}${Math.random().toString(16).slice(2, 10)}`;
+        const body = this.buildMultipartBody(boundary, this.uploadToken, key, image.name, buffer);
+
+        const response = await requestUrl({
+            url: QINIU_UPLOAD_HOST,
+            method: "POST",
+            headers: {
+                "Content-Type": `multipart/form-data; boundary=${boundary}`,
+            },
+            body: body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength),
+            throw: false,
+        });
+
+        if (response.status !== 200) {
+            throw new Error(`Qiniu Kodo upload failed (${response.status}): ${response.text || "no response body"}`);
+        }
+
+        const data = response.json as {key?: string};
+        const returnedKey = data?.key ?? key;
+        return UploaderUtils.customizeDomainName(`${this.setting.customDomainName}/${returnedKey}`, "");
     }
 
     updateToken(): void {
         if (this.tokenExpireTime && this.tokenExpireTime > Date.now()) {
             return;
         }
-        const mac = new qiniu.auth.digest.Mac(this.setting.accessKey, this.setting.secretKey);
-        const expires = 3600;
-        this.tokenExpireTime = Date.now() + expires * 1000;
-        const options = {
+        const deadline = Math.floor(Date.now() / 1000) + TOKEN_LIFETIME_SECONDS;
+        this.tokenExpireTime = deadline * 1000;
+        const policy = {
             scope: this.setting.bucket,
-            expires: expires,
+            deadline,
             returnBody:
                 '{"key":"$(key)","hash":"$(etag)","bucket":"$(bucket)","name":"$(x:name)","age":$(x:age)}',
         };
-        const putPolicy = new qiniu.rs.PutPolicy(options);
-        this.uploadToken = putPolicy.uploadToken(mac);
+        const encodedPolicy = urlSafeBase64(Buffer.from(JSON.stringify(policy), "utf8"));
+        const signature = urlSafeBase64(createHmac("sha1", this.setting.secretKey).update(encodedPolicy).digest());
+        this.uploadToken = `${this.setting.accessKey}:${signature}:${encodedPolicy}`;
     }
+
+    private buildMultipartBody(
+        boundary: string,
+        token: string,
+        key: string,
+        filename: string,
+        file: Buffer,
+    ): Buffer {
+        const CRLF = "\r\n";
+        const parts: Buffer[] = [];
+        const fieldHeader = (name: string) =>
+            `--${boundary}${CRLF}Content-Disposition: form-data; name="${name}"${CRLF}${CRLF}`;
+
+        parts.push(Buffer.from(fieldHeader("token") + token + CRLF, "utf8"));
+        parts.push(Buffer.from(fieldHeader("key") + key + CRLF, "utf8"));
+
+        const fileHeader =
+            `--${boundary}${CRLF}` +
+            `Content-Disposition: form-data; name="file"; filename="${encodeURIComponent(filename)}"${CRLF}` +
+            `Content-Type: application/octet-stream${CRLF}${CRLF}`;
+        parts.push(Buffer.from(fileHeader, "utf8"));
+        parts.push(file);
+        parts.push(Buffer.from(`${CRLF}--${boundary}--${CRLF}`, "utf8"));
+
+        return Buffer.concat(parts);
+    }
+}
+
+function urlSafeBase64(input: Buffer): string {
+    return input.toString("base64").replace(/\+/g, "-").replace(/\//g, "_");
 }
 
 export interface KodoSetting {

--- a/src/uploader/r2/r2Uploader.ts
+++ b/src/uploader/r2/r2Uploader.ts
@@ -1,21 +1,22 @@
 import ImageUploader from "../imageUploader";
-import AWS from 'aws-sdk';
+import {PutObjectCommand, S3Client} from "@aws-sdk/client-s3";
 import {UploaderUtils} from "../uploaderUtils";
 
 export default class R2Uploader implements ImageUploader {
-  private readonly r2!: AWS.S3;
+  private readonly r2!: S3Client;
   private readonly bucket!: string;
   private pathTmpl: string;
   private customDomainName: string;
 
   constructor(setting: R2Setting) {
-    this.r2 = new AWS.S3({
-      accessKeyId: setting.accessKeyId,
-      secretAccessKey: setting.secretAccessKey,
+    this.r2 = new S3Client({
+      credentials: {
+        accessKeyId: setting.accessKeyId,
+        secretAccessKey: setting.secretAccessKey,
+      },
       endpoint: setting.endpoint,
       region: 'auto', // Cloudflare R2 uses 'auto' region
-      s3ForcePathStyle: true, // Needed for Cloudflare R2
-      signatureVersion: 'v4', // Cloudflare R2 uses v4 signatures
+      forcePathStyle: true, // Needed for Cloudflare R2
     });
     this.bucket = setting.bucketName;
     this.pathTmpl = setting.path;
@@ -23,35 +24,17 @@ export default class R2Uploader implements ImageUploader {
   }
 
   async upload(image: File, fullPath: string): Promise<string> {
-    const arrayBuffer = await this.readFileAsArrayBuffer(image);
+    const arrayBuffer = await image.arrayBuffer();
     const uint8Array = new Uint8Array(arrayBuffer);
     let path = UploaderUtils.generateName(this.pathTmpl, image.name);
     path = path.replace(/^\/+/, ''); // remove the /
-    const params = {
+    await this.r2.send(new PutObjectCommand({
       Bucket: this.bucket,
       Key: path,
       Body: uint8Array,
       ContentType: `image/${image.name.split('.').pop()}`,
-    };
-    return new Promise((resolve, reject) => {
-      this.r2.upload(params, (err, data) => {
-        if (err) {
-          reject(err instanceof Error ? err : new Error(String(err)));
-        } else {
-          const dst = data.Location.split(`/${this.bucket}/`).pop();
-          resolve(UploaderUtils.customizeDomainName(dst, this.customDomainName));
-        }
-      });
-    });
-  }
-
-  private readFileAsArrayBuffer(file: File): Promise<ArrayBuffer> {
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onload = () => resolve(reader.result as ArrayBuffer);
-      reader.onerror = reject;
-      reader.readAsArrayBuffer(file);
-    });
+    }));
+    return UploaderUtils.customizeDomainName(path, this.customDomainName);
   }
 }
 

--- a/src/uploader/s3/awsS3Uploader.ts
+++ b/src/uploader/s3/awsS3Uploader.ts
@@ -1,53 +1,41 @@
 import ImageUploader from "../imageUploader";
-import AWS from 'aws-sdk';
+import {PutObjectCommand, S3Client} from "@aws-sdk/client-s3";
 import {UploaderUtils} from "../uploaderUtils";
 
 export default class AwsS3Uploader implements ImageUploader {
-  private readonly s3!: AWS.S3;
+  private readonly s3!: S3Client;
   private readonly bucket!: string;
+  private readonly region: string;
   private pathTmpl: string;
   private customDomainName: string;
 
 
   constructor(setting: AwsS3Setting) {
-    this.s3 = new AWS.S3({
-      accessKeyId: setting.accessKeyId,
-      secretAccessKey: setting.secretAccessKey,
-      region: setting.region
+    this.s3 = new S3Client({
+      credentials: {
+        accessKeyId: setting.accessKeyId,
+        secretAccessKey: setting.secretAccessKey,
+      },
+      region: setting.region,
     });
     this.bucket = setting.bucketName;
+    this.region = setting.region;
     this.pathTmpl = setting.path;
     this.customDomainName = setting.customDomainName;
   }
 
   async upload(image: File, fullPath: string): Promise<string> {
-    const arrayBuffer = await this.readFileAsArrayBuffer(image);
+    const arrayBuffer = await image.arrayBuffer();
     const uint8Array = new Uint8Array(arrayBuffer);
     let path = UploaderUtils.generateName(this.pathTmpl, image.name);
     path = path.replace(/^\/+/, ''); // remove the /
-    const params = {
+    await this.s3.send(new PutObjectCommand({
       Bucket: this.bucket,
       Key: path,
       Body: uint8Array,
-    };
-    return new Promise((resolve, reject) => {
-      this.s3.upload(params, (err, data) => {
-        if (err) {
-          reject(err instanceof Error ? err : new Error(String(err)));
-        } else {
-          resolve(UploaderUtils.customizeDomainName(data.Location, this.customDomainName));
-        }
-      });
-    });
-  }
-
-  private readFileAsArrayBuffer(file: File): Promise<ArrayBuffer> {
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onload = () => resolve(reader.result as ArrayBuffer);
-      reader.onerror = reject;
-      reader.readAsArrayBuffer(file);
-    });
+    }));
+    const location = `https://${this.bucket}.s3.${this.region}.amazonaws.com/${path}`;
+    return UploaderUtils.customizeDomainName(location, this.customDomainName);
   }
 }
 export interface AwsS3Setting {


### PR DESCRIPTION
## Why

Bundle analysis after batches 4 and 4b showed **3.4 MB of `typescript/lib/typescript.js`** sitting in the production bundle. The trail was:

```
qiniu -> urllib -> proxy-agent -> pac-resolver -> degenerator -> vm2 -> typescript
```

`vm2` pulls in the entire TypeScript compiler as a sandboxed-execution dependency. The qiniu SDK was the root of this dependency chain; the `KodoUploader` only needed signed token generation and a single multipart POST.

## Changes

- Rewrite `src/uploader/qiniu/kodoUploader.ts` to use Obsidian's `requestUrl` with the documented Qiniu upload-token scheme per the [Qiniu API reference](https://developer.qiniu.com/kodo/1208/upload-token):

  ```
  encodedPolicy = urlsafe-base64(JSON.stringify({scope, deadline, returnBody}))
  signature     = urlsafe-base64(HMAC-SHA1(secretKey, encodedPolicy))
  uploadToken   = accessKey:signature:encodedPolicy
  ```

- Upload now POSTs a hand-rolled `multipart/form-data` body to `https://upload.qiniup.com` with `token`, `key`, and `file` fields.
- Token cache + 3600 s lifetime preserved; same `KodoSetting` shape; same `customDomainName` composition; same `returnBody` template.
- Use Node's built-in `crypto` (`createHmac`) — consistent with batch 4b.

## Result

| Metric | Before | After |
| --- | --- | --- |
| `dist/main.js` | 7.0 MB | **1.7 MB** (-76%) |

- Lint: 0 errors / 176 warnings.
- Tests: 71/71 pass.
- Public surface unchanged.

## Cumulative bundle reduction across batch 4 series

| Stage | `dist/main.js` |
| --- | --- |
| Pre-batch-4 | 16 MB |
| After 4 (aws-sdk v3) | 7.2 MB |
| After 4b (ali-oss removed) | 7.0 MB |
| **After 4c (qiniu removed)** | **1.7 MB** |

Comfortably under the 5 MB Obsidian Sync cap. `cos-nodejs-sdk-v5` (444 KB on disk) remains as the only sizeable third-party uploader SDK; a future Batch 4d could replace it with the same `requestUrl` + inline-signing pattern if further reduction is desired.

## Stack

Based on `compliance/batch-4b-replace-ali-oss` (PR #64). GitHub will auto-retarget to `main` as ancestor PRs merge.