### PR TITLE
Compliance batch 4d: replace cos-nodejs-sdk-v5 with requestUrl + inline signing

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -11,18 +11,7 @@ const context = await esbuild.context({
   format: "cjs",
   target: "es2022",
   mainFields: ["browser", "module", "main"],
-  external: [
-    "obsidian",
-    "electron",
-    // urllib (transitive via cos-nodejs-sdk-v5, qiniu) lazy-loads proxy agents
-    // that are not installed; mark external until those SDKs are removed.
-    "proxy-agent",
-    "agent-base",
-    "https-proxy-agent",
-    "http-proxy-agent",
-    "socks-proxy-agent",
-    "pac-proxy-agent",
-  ],
+  external: ["obsidian", "electron"],
   outfile: "dist/main.js",
   sourcemap: prod ? false : "inline",
   minify: prod,

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1048.0",
     "@octokit/rest": "^19.0.4",
-    "cos-nodejs-sdk-v5": "^2.14.6",
     "imagekit": "^5.0.0"
   }
 }

--- a/src/uploader/cos/cosUploader.ts
+++ b/src/uploader/cos/cosUploader.ts
@@ -1,37 +1,109 @@
-import COS from "cos-nodejs-sdk-v5"
+import {requestUrl} from "obsidian";
+import {createHash, createHmac} from "crypto";
 import ImageUploader from "../imageUploader";
 import {UploaderUtils} from "../uploaderUtils";
 
+const EXTENSION_MIME_MAP: Record<string, string> = {
+    jpg: "image/jpeg",
+    jpeg: "image/jpeg",
+    png: "image/png",
+    gif: "image/gif",
+    svg: "image/svg+xml",
+    webp: "image/webp",
+    bmp: "image/bmp",
+};
+
+const SIGN_LIFETIME_SECONDS = 600;
+
 export default class CosUploader implements ImageUploader {
 
-    private readonly client!: COS;
     private readonly pathTmpl: string;
     private readonly customDomainName: string;
     private readonly region: string;
     private readonly bucket: string;
+    private readonly secretId: string;
+    private readonly secretKey: string;
 
     constructor(setting: CosSetting) {
-        this.client = new COS({
-            SecretId: setting.secretId,
-            SecretKey: setting.secretKey,
-        })
         this.pathTmpl = setting.path;
         this.customDomainName = setting.customDomainName;
         this.bucket = setting.bucket;
         this.region = setting.region;
+        this.secretId = setting.secretId;
+        this.secretKey = setting.secretKey;
     }
 
     async upload(image: File, fullPath: string): Promise<string> {
-        const result = this.client.putObject({
-            Body: Buffer.from((await image.arrayBuffer())),
-            Bucket: this.bucket,
-            Region: this.region,
-            Key: UploaderUtils.generateName(this.pathTmpl, image.name),
+        const key = UploaderUtils.generateName(this.pathTmpl, image.name).replace(/^\/+/, "");
+        const body = await image.arrayBuffer();
+        const contentType = this.resolveContentType(image);
+        const host = `${this.bucket}.cos.${this.region}.myqcloud.com`;
+        const url = `https://${host}/${encodePathKey(key)}`;
+        const authorization = this.buildAuthorization("put", `/${key}`, host);
+
+        const response = await requestUrl({
+            url,
+            method: "PUT",
+            headers: {
+                Authorization: authorization,
+                Host: host,
+                "Content-Type": contentType,
+            },
+            body,
+            throw: false,
         });
-        let url = 'https://' + (await result).Location;
+
+        if (response.status < 200 || response.status >= 300) {
+            throw new Error(`Tencent COS upload failed (${response.status}): ${response.text || "no response body"}`);
+        }
+
         return UploaderUtils.customizeDomainName(url, this.customDomainName);
     }
 
+    /**
+     * Builds the Tencent COS XML-API authorization header per
+     * https://www.tencentcloud.com/document/product/436/7778
+     */
+    private buildAuthorization(method: string, pathname: string, host: string): string {
+        const now = Math.floor(Date.now() / 1000);
+        const keyTime = `${now};${now + SIGN_LIFETIME_SECONDS}`;
+        const signKey = createHmac("sha1", this.secretKey).update(keyTime).digest("hex");
+
+        // Only the Host header is signed; no query parameters.
+        const headerList = "host";
+        const headersString = `host=${encodeURIComponent(host).toLowerCase()}`;
+
+        const httpString = `${method.toLowerCase()}\n${pathname}\n\n${headersString}\n`;
+        const httpStringSha1 = createHash("sha1").update(httpString).digest("hex");
+        const stringToSign = `sha1\n${keyTime}\n${httpStringSha1}\n`;
+        const signature = createHmac("sha1", signKey).update(stringToSign).digest("hex");
+
+        return [
+            "q-sign-algorithm=sha1",
+            `q-ak=${this.secretId}`,
+            `q-sign-time=${keyTime}`,
+            `q-key-time=${keyTime}`,
+            `q-header-list=${headerList}`,
+            "q-url-param-list=",
+            `q-signature=${signature}`,
+        ].join("&");
+    }
+
+    private resolveContentType(image: File): string {
+        if (image.type) {
+            return image.type;
+        }
+        const ext = image.name.split(".").pop()?.toLowerCase() ?? "";
+        return EXTENSION_MIME_MAP[ext] || "application/octet-stream";
+    }
+}
+
+/**
+ * Encode an object key for inclusion in a COS URL. Slashes are preserved as
+ * path separators; every other segment is percent-encoded.
+ */
+function encodePathKey(key: string): string {
+    return key.split("/").map(encodeURIComponent).join("/");
 }
 
 export interface CosSetting {


### PR DESCRIPTION
## Why

`cos-nodejs-sdk-v5` was the last remaining heavy third-party uploader SDK. The `CosUploader` used it only for a single `PutObject` call, but the package transitively pulled in `request` (deprecated), `tough-cookie`, `psl`, and the rest of an HTTP stack we already replaced for every other uploader.

## Changes

- Rewrite `src/uploader/cos/cosUploader.ts` to use Obsidian's `requestUrl` with the documented Tencent COS XML-API v5 signature scheme per the [Tencent reference](https://www.tencentcloud.com/document/product/436/7778):

  ```
  SignKey   = HMAC-SHA1(SecretKey, KeyTime)         hex
  HttpStr   = method\npath\n\nencoded-headers\n
  StrToSign = sha1\nKeyTime\nSHA1(HttpStr)\n
  Signature = HMAC-SHA1(SignKey, StrToSign)         hex
  Authorization = q-sign-algorithm=sha1&q-ak=...&q-sign-time=...&q-key-time=...&q-header-list=host&q-url-param-list=&q-signature=...
  ```

- Only the `Host` header is signed (no query params), matching what the SDK did for a vanilla `PutObject`.
- Use Node's built-in `crypto` (`createHash`, `createHmac`) — consistent with batches 4b and 4c.
- Object key is URL-encoded per segment so embedded path separators survive intact.
- Same `CosSetting` shape, same returned URL pattern, same `customDomainName` rewrite, same MIME fallback added in earlier batches.

## Result

| Metric | Before | After |
| --- | --- | --- |
| `dist/main.js` | 1.7 MB | **644 KB** (-62%) |

- Lint: 0 errors / 176 warnings.
- Tests: 71/71 pass.
- Public surface unchanged.

## Cumulative bundle reduction across the batch 4 series

| Stage | `dist/main.js` |
| --- | --- |
| Pre-batch-4 | 16 MB |
| After 4 (aws-sdk v3) | 7.2 MB |
| After 4b (ali-oss removed) | 7.0 MB |
| After 4c (qiniu removed) | 1.7 MB |
| **After 4d (cos removed)** | **644 KB** (-96%) |

The bundle is now in line with typical Obsidian community plugins. The only remaining `dependencies` entries are `@aws-sdk/client-s3`, `@octokit/rest`, and `imagekit` (which `imagekitUploader` no longer imports at runtime — it already uses `requestUrl`; that dep can be removed in a follow-up if desired).

## Stack

Based on `compliance/batch-4c-replace-qiniu` (PR #65). GitHub will auto-retarget to `main` as ancestor PRs merge.