### PR TITLE
chore: remove unused imagekit dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1048.0",
-    "@octokit/rest": "^19.0.4",
-    "imagekit": "^5.0.0"
+    "@octokit/rest": "^19.0.4"
   }
 }


### PR DESCRIPTION
## Summary
- Drop the `imagekit` npm package from `dependencies`. It has been unused since `imagekitUploader` was rewritten to call the ImageKit upload API via Obsidian's `requestUrl` (the SDK's Node.js HTTP stack caused SIGSEGV in the Electron sandbox).

## Verification
- `npm run build` -> `dist/main.js` unchanged at 644 KB (already tree-shaken).
- `npm run lint` -> 176 warnings, 0 errors.
- `npm test` -> 71/71 passing.

## Stack
Base: #66 (Batch 4d). Part of the compliance stack #60 -> #66 -> this.