### PR TITLE
fix: send Imgur uploads as base64 form body

### DIFF
--- a/src/uploader/imgur/imgurAnonymousUploader.ts
+++ b/src/uploader/imgur/imgurAnonymousUploader.ts
@@ -12,13 +12,28 @@ export default class ImgurAnonymousUploader implements ImageUploader {
     }
 
     async upload(image: File, path: string): Promise<string> {
-        const requestData = new FormData();
-        requestData.append("image", image);
+        // Imgur /3/image accepts base64-encoded image bytes when the request
+        // body is application/x-www-form-urlencoded with the `image` field.
+        // requestUrl() does not support multipart/form-data, so use base64.
+        const buf = await image.arrayBuffer();
+        const bytes = new Uint8Array(buf);
+        let binary = "";
+        for (let i = 0; i < bytes.length; i++) {
+            binary += String.fromCharCode(bytes[i]);
+        }
+        const b64 = btoa(binary);
+        const body = `image=${encodeURIComponent(b64)}&type=base64`;
+
         const resp = await requestUrl({
-            body: await image.arrayBuffer(),
-            headers: {Authorization: `Client-ID ${this.clientId}`},
+            body,
+            headers: {
+                Authorization: `Client-ID ${this.clientId}`,
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
             method: "POST",
-            url: `${IMGUR_API_BASE}image`})
+            throw: false,
+            url: `${IMGUR_API_BASE}image`,
+        });
 
         if (resp.status != 200) {
             handleImgurErrorResponse(resp);
@@ -32,8 +47,9 @@ export interface ImgurAnonymousSetting {
 }
 
 export function handleImgurErrorResponse(resp: RequestUrlResponse): void {
-    if (resp.headers["Content-Type"] === "application/json") {
+    const contentType = resp.headers["Content-Type"] || resp.headers["content-type"];
+    if (contentType && contentType.startsWith("application/json")) {
         throw new ApiError((resp.json as ImgurErrorData).data.error);
     }
-    throw new Error(resp.text);
+    throw new Error(resp.text || `Imgur upload failed: HTTP ${resp.status}`);
 }


### PR DESCRIPTION
## Summary

Pre-existing bug discovered during end-to-end testing of the compliance stack against a live vault:

The Imgur anonymous uploader built a `FormData` object but never attached it to the request — instead it sent the raw PNG `arrayBuffer()` as the body. Imgur rejects this with `HTTP 400`.

`requestUrl()` does not support `multipart/form-data`, so the fix encodes the image as base64 and POSTs it as `application/x-www-form-urlencoded` with the documented `type=base64` parameter (per Imgur API v3 spec).

## Validation

Tested against `atbug` vault via Chrome DevTools Protocol (Obsidian `--remote-debugging-port=9223`):

- **Before**: `400 Bad Request` (raw PNG bytes rejected).
- **After**: request accepted; failure mode is now `403 "These actions are forbidden"`, which is an Imgur-side anonymous client_id ban — the upload protocol is correct.

Other backends verified end-to-end against live services in the same session:

| Backend                      | Result                                          |
| ---------------------------- | ----------------------------------------------- |
| Aliyun OSS (Batch 4b)        | `200 OK`, ETag MD5 match                        |
| AWS S3 v3 (Batch 4)          | `x-amz-request-id` confirmed S3 receipt         |
| ImageKit (Batch 4e)          | `200 OK`, file accessible at returned URL       |

## Hardening

- `handleImgurErrorResponse` now tolerates missing `Content-Type` and case variants (`Content-Type` vs `content-type`).
- Pass `throw: false` to `requestUrl` so non-200 responses route through the JSON error handler instead of throwing inside `requestUrl`.

## Stack

Base: `compliance/batch-7-readme-network-disclosure` (#69)
Position: Batch 8 of the IUT compliance stack.

🤖 Generated with [opencode](https://opencode.ai)
