### PR TITLE
perf: replace qiniu SDK with requestUrl + inline Kodo signing

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@aws-sdk/client-s3": "^3.1048.0",
     "@octokit/rest": "^19.0.4",
     "cos-nodejs-sdk-v5": "^2.14.6",
-    "imagekit": "^5.0.0",
-    "qiniu": "^7.14.0"
+    "imagekit": "^5.0.0"
   }
 }

--- a/src/uploader/qiniu/kodoUploader.ts
+++ b/src/uploader/qiniu/kodoUploader.ts
@@ -1,6 +1,10 @@
+import {requestUrl} from "obsidian";
+import {createHmac} from "crypto";
 import ImageUploader from "../imageUploader";
-import qiniu from "qiniu";
 import {UploaderUtils} from "../uploaderUtils";
+
+const QINIU_UPLOAD_HOST = "https://upload.qiniup.com";
+const TOKEN_LIFETIME_SECONDS = 3600;
 
 export default class KodoUploader implements ImageUploader {
 
@@ -15,47 +19,80 @@ export default class KodoUploader implements ImageUploader {
     async upload(image: File, path: string): Promise<string> {
         //check custom domain name
         if (!this.setting.customDomainName || this.setting.customDomainName.trim() === "") {
-            throw new Error("Custom domain name is required for Qiniu Kodo.")
+            throw new Error("Custom domain name is required for Qiniu Kodo.");
         }
         this.updateToken();
-        const config = new qiniu.conf.Config();
-        const formUploader = new qiniu.form_up.FormUploader(config);
-        const putExtra = new qiniu.form_up.PutExtra();
-        let key = UploaderUtils.generateName(this.setting.path, image.name.replaceAll(' ', '_')); //replace space with _ in file name
-        
-        // Read file buffer instead of using filesystem path for better web image support
+        const key = UploaderUtils.generateName(this.setting.path, image.name.replaceAll(" ", "_"));
         const buffer = Buffer.from(await image.arrayBuffer());
-        
-        return formUploader
-            .put(this.uploadToken, key, buffer, putExtra)
-            .then(({data, resp}) => {
-                if (resp.statusCode === 200) {
-                    return this.setting.customDomainName + '/' + data.key;
-                } else {
-                    throw data;
-                }
-            })
-            .catch((err) => {
-                throw err
-            });
+
+        const boundary = `----ObsidianFormBoundary${Date.now().toString(16)}${Math.random().toString(16).slice(2, 10)}`;
+        const body = this.buildMultipartBody(boundary, this.uploadToken, key, image.name, buffer);
+
+        const response = await requestUrl({
+            url: QINIU_UPLOAD_HOST,
+            method: "POST",
+            headers: {
+                "Content-Type": `multipart/form-data; boundary=${boundary}`,
+            },
+            body: body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength),
+            throw: false,
+        });
+
+        if (response.status !== 200) {
+            throw new Error(`Qiniu Kodo upload failed (${response.status}): ${response.text || "no response body"}`);
+        }
+
+        const data = response.json as {key?: string};
+        const returnedKey = data?.key ?? key;
+        return UploaderUtils.customizeDomainName(`${this.setting.customDomainName}/${returnedKey}`, "");
     }
 
     updateToken(): void {
         if (this.tokenExpireTime && this.tokenExpireTime > Date.now()) {
             return;
         }
-        const mac = new qiniu.auth.digest.Mac(this.setting.accessKey, this.setting.secretKey);
-        const expires = 3600;
-        this.tokenExpireTime = Date.now() + expires * 1000;
-        const options = {
+        const deadline = Math.floor(Date.now() / 1000) + TOKEN_LIFETIME_SECONDS;
+        this.tokenExpireTime = deadline * 1000;
+        const policy = {
             scope: this.setting.bucket,
-            expires: expires,
+            deadline,
             returnBody:
                 '{"key":"$(key)","hash":"$(etag)","bucket":"$(bucket)","name":"$(x:name)","age":$(x:age)}',
         };
-        const putPolicy = new qiniu.rs.PutPolicy(options);
-        this.uploadToken = putPolicy.uploadToken(mac);
+        const encodedPolicy = urlSafeBase64(Buffer.from(JSON.stringify(policy), "utf8"));
+        const signature = urlSafeBase64(createHmac("sha1", this.setting.secretKey).update(encodedPolicy).digest());
+        this.uploadToken = `${this.setting.accessKey}:${signature}:${encodedPolicy}`;
     }
+
+    private buildMultipartBody(
+        boundary: string,
+        token: string,
+        key: string,
+        filename: string,
+        file: Buffer,
+    ): Buffer {
+        const CRLF = "\r\n";
+        const parts: Buffer[] = [];
+        const fieldHeader = (name: string) =>
+            `--${boundary}${CRLF}Content-Disposition: form-data; name="${name}"${CRLF}${CRLF}`;
+
+        parts.push(Buffer.from(fieldHeader("token") + token + CRLF, "utf8"));
+        parts.push(Buffer.from(fieldHeader("key") + key + CRLF, "utf8"));
+
+        const fileHeader =
+            `--${boundary}${CRLF}` +
+            `Content-Disposition: form-data; name="file"; filename="${encodeURIComponent(filename)}"${CRLF}` +
+            `Content-Type: application/octet-stream${CRLF}${CRLF}`;
+        parts.push(Buffer.from(fileHeader, "utf8"));
+        parts.push(file);
+        parts.push(Buffer.from(`${CRLF}--${boundary}--${CRLF}`, "utf8"));
+
+        return Buffer.concat(parts);
+    }
+}
+
+function urlSafeBase64(input: Buffer): string {
+    return input.toString("base64").replace(/\+/g, "-").replace(/\//g, "_");
 }
 
 export interface KodoSetting {


### PR DESCRIPTION
## Why

Bundle analysis after batches 4 and 4b showed **3.4 MB of `typescript/lib/typescript.js`** sitting in the production bundle. The trail was:

```
qiniu -> urllib -> proxy-agent -> pac-resolver -> degenerator -> vm2 -> typescript
```

`vm2` pulls in the entire TypeScript compiler as a sandboxed-execution dependency. The qiniu SDK was the root of this dependency chain; the `KodoUploader` only needed signed token generation and a single multipart POST.

## Changes

- Rewrite `src/uploader/qiniu/kodoUploader.ts` to use Obsidian's `requestUrl` with the documented Qiniu upload-token scheme per the [Qiniu API reference](https://developer.qiniu.com/kodo/1208/upload-token):

  ```
  encodedPolicy = urlsafe-base64(JSON.stringify({scope, deadline, returnBody}))
  signature     = urlsafe-base64(HMAC-SHA1(secretKey, encodedPolicy))
  uploadToken   = accessKey:signature:encodedPolicy
  ```

- Upload now POSTs a hand-rolled `multipart/form-data` body to `https://upload.qiniup.com` with `token`, `key`, and `file` fields.
- Token cache + 3600 s lifetime preserved; same `KodoSetting` shape; same `customDomainName` composition; same `returnBody` template.
- Use Node's built-in `crypto` (`createHmac`) — consistent with batch 4b.

## Result

| Metric | Before | After |
| --- | --- | --- |
| `dist/main.js` | 7.0 MB | **1.7 MB** (-76%) |

- Lint: 0 errors / 176 warnings.
- Tests: 71/71 pass.
- Public surface unchanged.

## Cumulative bundle reduction across batch 4 series

| Stage | `dist/main.js` |
| --- | --- |
| Pre-batch-4 | 16 MB |
| After 4 (aws-sdk v3) | 7.2 MB |
| After 4b (ali-oss removed) | 7.0 MB |
| **After 4c (qiniu removed)** | **1.7 MB** |

Comfortably under the 5 MB Obsidian Sync cap. `cos-nodejs-sdk-v5` (444 KB on disk) remains as the only sizeable third-party uploader SDK; a future Batch 4d could replace it with the same `requestUrl` + inline-signing pattern if further reduction is desired.

## Stack

Based on `compliance/batch-4b-replace-ali-oss` (PR #64). GitHub will auto-retarget to `main` as ancestor PRs merge.

---

_Recreated from #65 (auto-closed when the batch-4b base branch was deleted on squash-merge)._