### PR TITLE
fix(cos): do not set Host header in requestUrl

### DIFF
--- a/src/uploader/cos/cosUploader.ts
+++ b/src/uploader/cos/cosUploader.ts
@@ -45,8 +45,11 @@ export default class CosUploader implements ImageUploader {
             url,
             method: "PUT",
             headers: {
+                // NOTE: do not set `Host` here. Electron/Chromium forbids
+                // explicitly setting the Host header (`net::ERR_INVALID_ARGUMENT`).
+                // The browser sets it automatically from the URL and COS
+                // validates it against the signature.
                 Authorization: authorization,
-                Host: host,
                 "Content-Type": contentType,
             },
             body,


### PR DESCRIPTION
## Why

Setting an explicit `Host` header on `requestUrl` calls is rejected by Electron/Chromium with `net::ERR_INVALID_ARGUMENT`. The browser sets `Host` automatically from the URL.

## What

Drop the `Host` header from the Tencent COS upload request. The signature still embeds `host=<bucket>.cos.<region>.myqcloud.com` and COS validates the Host received on the wire against that value, so the request is still correctly authenticated.

## How tested

End-to-end CDP test against a live `atbug-1254180493` COS bucket in `ap-guangzhou`. Before the fix the upload failed with `net::ERR_INVALID_ARGUMENT`; after the fix the PUT returns 200 and the object is reachable at the bucket URL.

Caught during regression testing of #66 (cos-nodejs-sdk-v5 -> requestUrl migration).