### PR TITLE
docs: document CDP-based E2E testing workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,10 +8,11 @@ This is a TypeScript-based Obsidian plugin that processes markdown documents, de
 
 ## Tech Stack
 
-- **Language**: TypeScript 4.0.3
+- **Language**: TypeScript 4.x
 - **Target**: ES2021, CommonJS modules
-- **Framework**: Obsidian Plugin API (≥ 0.11.0)
-- **Build Tool**: obsidian-plugin-cli
+- **Framework**: Obsidian Plugin API (minAppVersion 0.12.16)
+- **Build Tool**: esbuild via custom `esbuild.config.mjs` (externals: `obsidian`, `electron`)
+- **Test Runner**: Vitest 4.x
 - **Platform**: Desktop only (Windows/macOS/Linux)
 
 ## Project Structure
@@ -108,7 +109,7 @@ Example: `/{year}/{mon}/{day}/{filename}` → `/2024/01/17/image.jpg`
 ## Code Style & Conventions
 
 ### TypeScript Guidelines
-- Use TypeScript strict mode (enabled in [`tsconfig.json`](tsconfig.json))
+- TypeScript strict mode is **not** currently enabled in [`tsconfig.json`](tsconfig.json); the lint suite covers most type-safety gaps via `typescript-eslint`. New code should still be written as if strict were on
 - Prefer interfaces over type aliases for public APIs
 - Use async/await over raw promises
 - Handle errors gracefully with try-catch blocks
@@ -198,6 +199,102 @@ Current test files:
 - `mermaidProcessor.test.ts` — Mermaid-to-PNG conversion
 - `mermaidRegex.test.ts` — Mermaid code block regex matching
 
+### End-to-End Testing via Chrome DevTools Protocol
+
+Unit tests can't catch Electron-specific runtime issues (e.g. Chromium rejecting an explicit `Host` header in `requestUrl`, which broke COS in 1.6.2 release candidate). We drive a **real Obsidian instance** over CDP to exercise the full publish flow against live cloud credentials.
+
+#### Setup
+
+1. Launch Obsidian with the CDP endpoint enabled:
+   ```bash
+   open -a Obsidian --args --remote-debugging-port=9223
+   ```
+2. Install the built plugin into a test vault that has live credentials for the providers you want to exercise:
+   ```bash
+   npm run build
+   cp main.js manifest.json styles.css \
+     "$VAULT/.obsidian/plugins/image-upload-toolkit/"
+   ```
+   Note: macOS TCC blocks `~/Documents` for non-Obsidian processes; place the test vault under `~/iCloud Drive/` or another accessible location.
+3. Enable the plugin in the vault (or hot-reload it via CDP — see "Reload Plugin via CDP" below).
+
+#### The `cdp.sh` Helper
+
+Requires `jq` and `websocat` on `$PATH` (`brew install jq websocat`). A minimal shell wrapper that posts a single `Runtime.evaluate` call to the active page and prints the JSON result. The pattern is:
+
+```bash
+#!/usr/bin/env bash
+# /tmp/cdp.sh — usage: cdp.sh '<js expression>'
+TARGET=$(curl -s http://localhost:9223/json/list \
+  | jq -r '[.[] | select(.type=="page")][0].webSocketDebuggerUrl')
+EXPR=$1
+jq -nc --arg e "$EXPR" '{
+  id: 1, method: "Runtime.evaluate",
+  params: { expression: $e, awaitPromise: true, returnByValue: true }
+}' | websocat -n1 "$TARGET"
+```
+
+Anything that evaluates to a JSON-serializable value comes back in `result.result.value`. Wrap multi-statement scripts in an async IIFE so `awaitPromise: true` can wait on the result.
+
+#### What You Have Access To Inside CDP
+
+The evaluated expression runs in the Obsidian renderer, so the full app is in scope:
+
+- `app`, `app.vault`, `app.workspace`, `app.commands`, `app.plugins`
+- `app.plugins.plugins["image-upload-toolkit"]` — live plugin instance
+  - `.settings` — current settings object (mutating it persists nothing until `saveData`)
+  - `.setupImageUploader()` — sync; rebuild the uploader after settings mutation
+- `app.commands.executeCommandById("image-upload-toolkit:publish-page")` — invokes the publish command (it's `checkCallback`-based, so don't call `.callback` directly)
+- `navigator.clipboard.readText()` — read what publish wrote to the clipboard
+- `activeDocument.querySelector(".modal.upload-progress-modal")` — assert the progress modal opened
+- `app.workspace.activeLeaf.view.editor.getValue()` — read the current editor buffer (do NOT use `app.vault.read(file)` after `editor.setValue()`; the latter doesn't auto-persist to disk)
+
+Avoid `require("obsidian")` and dynamic `import()` of the bundle from inside CDP — `obsidian` is an esbuild external and resolves to nothing at runtime in this context. Use the plugin instance for everything you need from the API.
+
+#### Reload Plugin via CDP
+
+After copying a new build into the vault:
+
+```bash
+/tmp/cdp.sh '(async () => {
+  await app.plugins.disablePlugin("image-upload-toolkit");
+  await app.plugins.enablePlugin("image-upload-toolkit");
+  return app.plugins.plugins["image-upload-toolkit"].manifest.version;
+})()'
+```
+
+#### Sample Test Scripts
+
+These scripts are not checked into the repo — they're working scratch under `/tmp/` during a release cycle. Treat the entries below as patterns to copy when you need to reproduce or extend coverage.
+
+- **Multi-store upload smoke test** (`/tmp/cdp-e2e-all.js`): iterates over `["ALIYUN_OSS", "AWS_S3", "Imagekit", "TENCENTCLOUD_COS", "IMGUR"]`, mutates `settings.imageStore`, calls `setupImageUploader()`, writes a sentinel PNG to the vault, runs the publish command, reads the clipboard, asserts the URL host matches the provider.
+- **Mermaid round-trip** (`/tmp/cdp-mermaid-e2e.js`): creates a note with a `mermaid` fence, runs publish, asserts the clipboard contains an uploaded image URL and the original document still contains the source fence.
+- **Supplemental coverage** (`/tmp/cdp-e2e-supplemental.js`): 13 cases covering settings panel rendering, progress modal lifecycle, web image download/skip, multi-block mermaid + theme/scale, `replaceOriginalDoc`, wiki-link images, hosted-URL dedupe, `ignoreProperties` toggle, and `imageAltText` toggle.
+
+#### Canonical IDs and Setting Keys
+
+When mutating settings programmatically, use the exact casing from `src/imageStore.ts`:
+
+| Store        | `ImageStore.id`     | Settings key             |
+|--------------|---------------------|--------------------------|
+| Imgur        | `IMGUR`             | `imgurAnonymousSetting`  |
+| Aliyun OSS   | `ALIYUN_OSS`        | `ossSetting`             |
+| ImageKit     | `Imagekit`          | `imagekitSetting`        |
+| AWS S3       | `AWS_S3`            | `awsS3Setting`           |
+| Tencent COS  | `TENCENTCLOUD_COS`  | `cosSetting`             |
+| Qiniu Kodo   | `QINIU_KUDO`        | `kodoSetting`            |
+| GitHub       | `GITHUB`            | `githubSetting`          |
+| Gyazo        | `GYAZO`             | `gyazoSetting`           |
+| Cloudflare R2| `CLOUDFLARE_R2`     | `r2Setting`              |
+| Backblaze B2 | `BACKBLAZE_B2`      | `b2Setting`              |
+
+#### Cleanup
+
+The publish flow uploads to **real buckets**. Test scripts should:
+- Prefix test filenames (e.g. `__iut-<timestamp>.png`) so they're easy to identify and prune from the bucket.
+- Snapshot `plugin.settings` before mutating and restore it after the run.
+- Delete any temp notes/images created in the vault via `app.vault.delete(file)`.
+
 ### Manual Testing Checklist
 
 1. Test each storage provider with sample images
@@ -212,6 +309,9 @@ Current test files:
 10. Verify mermaid theme setting applies correctly (default/dark/forest/neutral/base)
 11. Confirm mermaid source blocks are preserved when "Update original document" is enabled
 12. Verify mermaid-generated images are not double-uploaded when "Upload web images" is enabled
+13. Verify wiki-link image syntax (`![[image.png]]`) is uploaded and rewritten
+14. Verify `ignoreProperties` strips YAML frontmatter from the clipboard output when enabled
+15. Verify `imageAltText` populates alt text from the original filename when enabled
 
 ## Common Issues & Solutions
 
@@ -299,21 +399,19 @@ Follow conventional commit format:
 ## Dependencies
 
 ### Runtime
-- `obsidian` - Obsidian Plugin API (also provides `loadMermaid()` for mermaid rendering)
-- `@octokit/rest` - GitHub API client
-- `ali-oss` - Aliyun OSS SDK
-- `aws-sdk` - AWS S3 SDK (also used by Cloudflare R2 and Backblaze B2)
-- `cos-nodejs-sdk-v5` - TencentCloud COS SDK
-- `qiniu` - Qiniu Kodo SDK
-- `proxy-agent` - HTTP/HTTPS proxy support
+- `obsidian` (external, provided by the host; also exposes `requestUrl` and `loadMermaid`)
+- `@aws-sdk/client-s3` — used by AWS S3, Cloudflare R2, and Backblaze B2 uploaders (v3 modular SDK)
+- `@octokit/rest` — GitHub API client
 
-> **Note**: ImageKit and Gyazo use Obsidian's built-in `requestUrl` API directly instead of external SDKs. Mermaid rendering uses Obsidian's built-in `loadMermaid()` API — no bundled mermaid dependency.
+> **Note**: Aliyun OSS, Tencent COS, Qiniu Kodo, ImageKit, Gyazo, and Imgur uploaders use Obsidian's built-in `requestUrl` API with inline request signing — no provider SDKs are bundled. Mermaid rendering uses Obsidian's built-in `loadMermaid()` API. Bundle size dropped from ~16 MB to ~644 KB (−96%) as a result of dropping `ali-oss`, `cos-nodejs-sdk-v5`, `qiniu`, `aws-sdk` v2, and `proxy-agent`.
 
 ### Development
-- `typescript` - TypeScript compiler
-- `obsidian-plugin-cli` - Build tooling
-- `esbuild` - JavaScript bundler
-- `@types/node` - Node.js type definitions
+- `typescript` — TypeScript compiler
+- `esbuild` — JavaScript bundler (config in `esbuild.config.mjs`)
+- `vitest` — Test runner
+- `eslint` + `typescript-eslint` + `eslint-plugin-obsidianmd` — Linting (Obsidian-specific rules)
+- `@types/node` — Node.js type definitions
+- `jsdom` — DOM environment for unit tests
 
 ## Plugin Configuration
 
@@ -378,4 +476,4 @@ Settings are stored in `.obsidian/plugins/image-upload-toolkit/data.json`:
 
 ## Current Version
 
-v1.6.0 - Added Gyazo uploader support (PR #52), `normalizeId()` for backward-compatible provider alias resolution, and refactored all switch cases to use `ImageStore` constants.
+1.6.2 — Refactored all SDK-heavy uploaders (OSS, COS, Qiniu, S3, R2, B2) to use Obsidian's `requestUrl` API with inline signing; migrated AWS-family uploaders to `@aws-sdk/client-s3` v3; reduced bundle size from ~16 MB to ~644 KB; fixed Imgur anonymous upload payload encoding; fixed COS upload regression caused by explicit `Host` header rejection in Electron's `requestUrl`.


### PR DESCRIPTION
## Summary

Captures the Chrome DevTools Protocol-based end-to-end testing workflow used to validate the 1.6.2 release candidate, and refreshes several pieces of `AGENTS.md` that had drifted out of date.

## What's new

**New section: "End-to-End Testing via Chrome DevTools Protocol"** explains how we drive a real Obsidian Electron instance over CDP to exercise the full publish flow against live cloud credentials. Unit tests can't catch Electron-specific runtime issues — for example, Chromium rejecting an explicit `Host` header in `requestUrl`, which broke COS in the 1.6.2 release candidate and was only surfaced by this workflow.

The section documents:
- Obsidian launch with `--remote-debugging-port=9223`
- The `cdp.sh` helper pattern (curl `/json/list` → websocat `Runtime.evaluate`)
- What's reachable from the renderer context (`app`, plugin instance, `executeCommandById`, `navigator.clipboard`, the progress modal selector, editor buffer access)
- Known footguns: `require("obsidian")` and dynamic `import()` of the bundle don't work inside CDP; `editor.setValue()` doesn't persist to disk so assertions must read `editor.getValue()`
- Plugin hot-reload via `disablePlugin` + `enablePlugin`
- Sample script patterns (multi-store smoke test, mermaid round-trip, supplemental coverage suite)
- Canonical `ImageStore.id` and setting-key table (the casing inconsistencies — e.g. `Imagekit`, `QINIU_KUDO` — are easy to get wrong)
- Cleanup expectations for tests that hit real buckets

## What's refreshed

- **Tech Stack**: `obsidian-plugin-cli` → `esbuild` via `esbuild.config.mjs`; API `≥ 0.11.0` → `minAppVersion 0.12.16`; adds Vitest 4.x
- **Runtime dependencies**: drops `ali-oss`, `cos-nodejs-sdk-v5`, `qiniu`, `aws-sdk` v2, `proxy-agent` (all removed during the 1.6.2 SDK-stripping refactor); keeps `@aws-sdk/client-s3` and `@octokit/rest`. Notes the ~16 MB → ~644 KB bundle reduction.
- **Dev dependencies**: drops `obsidian-plugin-cli`; adds `eslint` + `typescript-eslint` + `eslint-plugin-obsidianmd`, `vitest`, `jsdom`
- **Manual Testing Checklist**: adds cases for wiki-link image syntax, `ignoreProperties` frontmatter stripping, `imageAltText` filename-based alt text
- **Current Version**: `1.6.0` → `1.6.2` with a short summary of the refactor scope

## Test plan

- Docs-only change; no code or build impact
- CI will still run (lint + test + build pass on identical sources)
