### PR TITLE
docs: check CDP E2E scripts into scripts/e2e/

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,99 +201,27 @@ Current test files:
 
 ### End-to-End Testing via Chrome DevTools Protocol
 
-Unit tests can't catch Electron-specific runtime issues (e.g. Chromium rejecting an explicit `Host` header in `requestUrl`, which broke COS in 1.6.2 release candidate). We drive a **real Obsidian instance** over CDP to exercise the full publish flow against live cloud credentials.
+Unit tests can't catch Electron-specific runtime issues (e.g. Chromium rejecting an explicit `Host` header in `requestUrl`, which broke COS in the 1.6.2 release candidate). The repo ships a small suite of CDP-driven scripts under [`scripts/e2e/`](scripts/e2e/) that drive a **real Obsidian instance** to exercise the full publish flow against live cloud credentials.
 
-#### Setup
+See [`scripts/e2e/README.md`](scripts/e2e/README.md) for the full workflow. Quick summary:
 
-1. Launch Obsidian with the CDP endpoint enabled:
+1. Launch Obsidian with `--remote-debugging-port=9223` (e.g. `open -a Obsidian --args --remote-debugging-port=9223`).
+2. Install the built plugin into a test vault that has live credentials for the providers you want to exercise. macOS TCC blocks `~/Documents` for non-Obsidian processes; place the test vault under `~/iCloud Drive/` or another accessible location.
+3. Run a script via the helper:
    ```bash
-   open -a Obsidian --args --remote-debugging-port=9223
+   ./scripts/e2e/cdp.sh "$(cat scripts/e2e/cdp-e2e-all.js)"
    ```
-2. Install the built plugin into a test vault that has live credentials for the providers you want to exercise:
-   ```bash
-   npm run build
-   cp main.js manifest.json styles.css \
-     "$VAULT/.obsidian/plugins/image-upload-toolkit/"
-   ```
-   Note: macOS TCC blocks `~/Documents` for non-Obsidian processes; place the test vault under `~/iCloud Drive/` or another accessible location.
-3. Enable the plugin in the vault (or hot-reload it via CDP — see "Reload Plugin via CDP" below).
 
-#### The `cdp.sh` Helper
+The helper (`scripts/e2e/cdp.sh`) requires `websocat` and `python3` on `PATH`. The expression runs in the Obsidian renderer with full access to `app`, `app.plugins.plugins["image-upload-toolkit"]`, `app.vault`, `app.commands.executeCommandById(...)`, `navigator.clipboard`, and `activeDocument`.
 
-Requires `jq` and `websocat` on `$PATH` (`brew install jq websocat`). A minimal shell wrapper that posts a single `Runtime.evaluate` call to the active page and prints the JSON result. The pattern is:
+Footguns worth knowing without opening the README:
 
-```bash
-#!/usr/bin/env bash
-# /tmp/cdp.sh — usage: cdp.sh '<js expression>'
-TARGET=$(curl -s http://localhost:9223/json/list \
-  | jq -r '[.[] | select(.type=="page")][0].webSocketDebuggerUrl')
-EXPR=$1
-jq -nc --arg e "$EXPR" '{
-  id: 1, method: "Runtime.evaluate",
-  params: { expression: $e, awaitPromise: true, returnByValue: true }
-}' | websocat -n1 "$TARGET"
-```
+- `require("obsidian")` and dynamic `import()` of the bundle don't work inside CDP — `obsidian` is an esbuild external and resolves to nothing at runtime in this context. Use the plugin instance.
+- `editor.setValue()` does NOT persist to disk. When asserting on `replaceOriginalDoc`, read `leaf.view.editor.getValue()`, not `app.vault.read(file)`.
+- Commands are `checkCallback`-based — use `app.commands.executeCommandById(...)`, not `.callback()`.
+- The progress modal opens asynchronously; poll `activeDocument.querySelector(".modal.upload-progress-modal")` for a few hundred ms.
 
-Anything that evaluates to a JSON-serializable value comes back in `result.result.value`. Wrap multi-statement scripts in an async IIFE so `awaitPromise: true` can wait on the result.
-
-#### What You Have Access To Inside CDP
-
-The evaluated expression runs in the Obsidian renderer, so the full app is in scope:
-
-- `app`, `app.vault`, `app.workspace`, `app.commands`, `app.plugins`
-- `app.plugins.plugins["image-upload-toolkit"]` — live plugin instance
-  - `.settings` — current settings object (mutating it persists nothing until `saveData`)
-  - `.setupImageUploader()` — sync; rebuild the uploader after settings mutation
-- `app.commands.executeCommandById("image-upload-toolkit:publish-page")` — invokes the publish command (it's `checkCallback`-based, so don't call `.callback` directly)
-- `navigator.clipboard.readText()` — read what publish wrote to the clipboard
-- `activeDocument.querySelector(".modal.upload-progress-modal")` — assert the progress modal opened
-- `app.workspace.activeLeaf.view.editor.getValue()` — read the current editor buffer (do NOT use `app.vault.read(file)` after `editor.setValue()`; the latter doesn't auto-persist to disk)
-
-Avoid `require("obsidian")` and dynamic `import()` of the bundle from inside CDP — `obsidian` is an esbuild external and resolves to nothing at runtime in this context. Use the plugin instance for everything you need from the API.
-
-#### Reload Plugin via CDP
-
-After copying a new build into the vault:
-
-```bash
-/tmp/cdp.sh '(async () => {
-  await app.plugins.disablePlugin("image-upload-toolkit");
-  await app.plugins.enablePlugin("image-upload-toolkit");
-  return app.plugins.plugins["image-upload-toolkit"].manifest.version;
-})()'
-```
-
-#### Sample Test Scripts
-
-These scripts are not checked into the repo — they're working scratch under `/tmp/` during a release cycle. Treat the entries below as patterns to copy when you need to reproduce or extend coverage.
-
-- **Multi-store upload smoke test** (`/tmp/cdp-e2e-all.js`): iterates over `["ALIYUN_OSS", "AWS_S3", "Imagekit", "TENCENTCLOUD_COS", "IMGUR"]`, mutates `settings.imageStore`, calls `setupImageUploader()`, writes a sentinel PNG to the vault, runs the publish command, reads the clipboard, asserts the URL host matches the provider.
-- **Mermaid round-trip** (`/tmp/cdp-mermaid-e2e.js`): creates a note with a `mermaid` fence, runs publish, asserts the clipboard contains an uploaded image URL and the original document still contains the source fence.
-- **Supplemental coverage** (`/tmp/cdp-e2e-supplemental.js`): 13 cases covering settings panel rendering, progress modal lifecycle, web image download/skip, multi-block mermaid + theme/scale, `replaceOriginalDoc`, wiki-link images, hosted-URL dedupe, `ignoreProperties` toggle, and `imageAltText` toggle.
-
-#### Canonical IDs and Setting Keys
-
-When mutating settings programmatically, use the exact casing from `src/imageStore.ts`:
-
-| Store        | `ImageStore.id`     | Settings key             |
-|--------------|---------------------|--------------------------|
-| Imgur        | `IMGUR`             | `imgurAnonymousSetting`  |
-| Aliyun OSS   | `ALIYUN_OSS`        | `ossSetting`             |
-| ImageKit     | `Imagekit`          | `imagekitSetting`        |
-| AWS S3       | `AWS_S3`            | `awsS3Setting`           |
-| Tencent COS  | `TENCENTCLOUD_COS`  | `cosSetting`             |
-| Qiniu Kodo   | `QINIU_KUDO`        | `kodoSetting`            |
-| GitHub       | `GITHUB`            | `githubSetting`          |
-| Gyazo        | `GYAZO`             | `gyazoSetting`           |
-| Cloudflare R2| `CLOUDFLARE_R2`     | `r2Setting`              |
-| Backblaze B2 | `BACKBLAZE_B2`      | `b2Setting`              |
-
-#### Cleanup
-
-The publish flow uploads to **real buckets**. Test scripts should:
-- Prefix test filenames (e.g. `__iut-<timestamp>.png`) so they're easy to identify and prune from the bucket.
-- Snapshot `plugin.settings` before mutating and restore it after the run.
-- Delete any temp notes/images created in the vault via `app.vault.delete(file)`.
+The scripts upload to **real buckets**. They prefix sentinel filenames (`iut-*`, `__iut-*`), snapshot/restore `plugin.settings`, and delete temp notes via `app.vault.delete(file)`.
 
 ### Manual Testing Checklist
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -84,6 +84,7 @@ export default tseslint.config(
 		"__mocks__/**",
 		"src/**/*.test.ts",
 		"tests/**",
+		"scripts/**",
 	]),
 );
 

--- a/scripts/e2e/README.md
+++ b/scripts/e2e/README.md
@@ -1,0 +1,96 @@
+# CDP-based End-to-End Tests
+
+These scripts drive a real Obsidian instance over the [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/) to validate the publish flow against live cloud credentials. Use them when:
+
+- You changed an uploader and want to confirm it still talks to the real bucket.
+- You're prepping a release and want to verify the user-visible publish flow end to end (UI modal, clipboard output, editor rewrite, mermaid conversion, etc).
+- You suspect an Electron-specific runtime issue that unit tests can't catch (e.g. `requestUrl` header validation).
+
+These are intentionally **not** wired into CI — they hit real buckets and require manual credentials.
+
+## Prerequisites
+
+- A test vault with the plugin installed and live credentials configured for whatever stores you want to exercise.
+- Obsidian launched with the CDP endpoint enabled:
+  ```bash
+  open -a Obsidian --args --remote-debugging-port=9223
+  ```
+- `websocat` and `python3` on `PATH`:
+  ```bash
+  brew install websocat
+  ```
+
+## The helper
+
+[`cdp.sh`](cdp.sh) wraps a single `Runtime.evaluate` call to the active page. Pass any JavaScript expression as the first argument; the expression runs in the Obsidian renderer with full access to `app`, `app.plugins`, `app.vault`, `navigator.clipboard`, `activeDocument`, etc.
+
+```bash
+# Inline expression
+./scripts/e2e/cdp.sh 'app.plugins.plugins["image-upload-toolkit"].manifest.version'
+
+# Load a script file
+./scripts/e2e/cdp.sh "$(cat scripts/e2e/cdp-e2e-all.js)"
+
+# Custom port
+PORT=9333 ./scripts/e2e/cdp.sh '...'
+```
+
+Multi-statement scripts must be wrapped in an async IIFE that returns a JSON-serializable value, because `awaitPromise: true` is passed and the result is fetched via `returnByValue: true`.
+
+## Scripts
+
+| File | Purpose |
+|------|---------|
+| [`cdp.sh`](cdp.sh) | Generic `Runtime.evaluate` helper |
+| [`cdp-e2e-all.js`](cdp-e2e-all.js) | Multi-store upload smoke test (iterates stores, uploads a 1x1 PNG sentinel via each) |
+| [`cdp-mermaid-e2e.js`](cdp-mermaid-e2e.js) | Mermaid round-trip: creates a fence, runs publish, asserts upload + fence removal |
+| [`cdp-e2e-supplemental.js`](cdp-e2e-supplemental.js) | 13-case suite covering settings panel, progress modal, web image download/skip, multi-mermaid, theme/scale, `replaceOriginalDoc`, wiki-link, hosted-URL dedupe, `ignoreProperties`, `imageAltText` |
+
+Each script has a header comment block documenting its assumptions and any constants you may need to edit (e.g. `STORE_ID`, `BUCKET_HOST_RE`).
+
+## Plugin reload via CDP
+
+After copying a new build into the vault, hot-reload the plugin:
+
+```bash
+./scripts/e2e/cdp.sh '(async () => {
+  await app.plugins.disablePlugin("image-upload-toolkit");
+  await app.plugins.enablePlugin("image-upload-toolkit");
+  return app.plugins.plugins["image-upload-toolkit"].manifest.version;
+})()'
+```
+
+## Footguns
+
+- **`require("obsidian")` and dynamic `import()` of the bundle don't work** inside the CDP expression — `obsidian` is an esbuild external and resolves to nothing at runtime in this context. Use the plugin instance (`app.plugins.plugins["image-upload-toolkit"]`) for everything you need from the API.
+- **`editor.setValue()` does NOT persist to disk.** When asserting on `replaceOriginalDoc` behavior, read `leaf.view.editor.getValue()`, not `app.vault.read(file)`.
+- **Commands are `checkCallback`-based.** Use `app.commands.executeCommandById("image-upload-toolkit:publish-page")`. Don't call `.callback` directly.
+- **Progress modal is async.** Don't query it once — poll `activeDocument.querySelector(".modal.upload-progress-modal")` for a few hundred ms after triggering publish.
+- **macOS TCC blocks `~/Documents`** for non-Obsidian processes. Place test vaults under `~/iCloud Drive/` or another accessible location.
+
+## Cleanup expectations
+
+The scripts upload to real buckets. They:
+
+- Prefix all sentinel filenames with `iut-` or `__iut-` so they're easy to identify and prune.
+- Snapshot `plugin.settings` before mutating and restore it after the run.
+- Delete temp notes/images created in the vault via `app.vault.delete(file)`.
+
+Residual sentinel files in your bucket are harmless but accumulate over time — periodically prune them with whatever bucket-management tool you use.
+
+## Canonical IDs and setting keys
+
+When mutating settings programmatically, use the exact casing from [`src/imageStore.ts`](../../src/imageStore.ts):
+
+| Store         | `ImageStore.id`    | Settings key            |
+|---------------|--------------------|-------------------------|
+| Imgur         | `IMGUR`            | `imgurAnonymousSetting` |
+| Aliyun OSS    | `ALIYUN_OSS`       | `ossSetting`            |
+| ImageKit      | `Imagekit`         | `imagekitSetting`       |
+| AWS S3        | `AWS_S3`           | `awsS3Setting`          |
+| Tencent COS   | `TENCENTCLOUD_COS` | `cosSetting`            |
+| Qiniu Kodo    | `QINIU_KUDO`       | `kodoSetting`           |
+| GitHub        | `GITHUB`           | `githubSetting`         |
+| Gyazo         | `GYAZO`            | `gyazoSetting`          |
+| Cloudflare R2 | `CLOUDFLARE_R2`    | `r2Setting`             |
+| Backblaze B2  | `BACKBLAZE_B2`     | `b2Setting`             |

--- a/scripts/e2e/cdp-e2e-all.js
+++ b/scripts/e2e/cdp-e2e-all.js
@@ -1,0 +1,64 @@
+// Multi-store upload smoke test for image-upload-toolkit.
+//
+// What it does:
+//   - Iterates a list of ImageStore IDs configured in the running vault.
+//   - For each store, mutates plugin.settings.imageStore, rebuilds the
+//     uploader, and uploads a 1x1 PNG sentinel directly via uploader.upload().
+//   - Reports per-store {ok, url|err} JSON.
+//   - Restores the original imageStore before returning.
+//
+// Usage:
+//   ./scripts/e2e/cdp.sh "$(cat scripts/e2e/cdp-e2e-all.js)"
+//
+// Pre-reqs:
+//   - The vault running in the CDP-attached Obsidian must have valid
+//     credentials configured for every store listed in `stores` below.
+//     Stores you don't have creds for will fail in the "upload" phase
+//     and won't pollute anything else.
+//   - Sentinel filenames are prefixed `iut-e2e-` so they are easy to
+//     identify and prune from your bucket after the run.
+
+(async () => {
+  const plugin = app.plugins.plugins["image-upload-toolkit"];
+  if (!plugin) throw new Error("image-upload-toolkit plugin not loaded");
+
+  const originalStore = plugin.settings.imageStore;
+
+  // 1x1 transparent PNG
+  const b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==";
+  const bin = atob(b64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+
+  // Adjust this list to match the stores you have creds for. Canonical
+  // IDs come from src/imageStore.ts (note casing!).
+  const stores = ["ALIYUN_OSS", "AWS_S3", "Imagekit", "IMGUR", "TENCENTCLOUD_COS"];
+  const results = [];
+
+  for (const store of stores) {
+    plugin.settings.imageStore = store;
+    try {
+      plugin.setupImageUploader();
+    } catch (e) {
+      results.push({ store, ok: false, phase: "setup", err: String(e?.message || e) });
+      continue;
+    }
+    const up = plugin.imageUploader;
+    if (!up) {
+      results.push({ store, ok: false, err: "no uploader after setup" });
+      continue;
+    }
+    const fname = `iut-e2e-${store.toLowerCase()}-${Date.now()}.png`;
+    try {
+      const file = new File([bytes], fname, { type: "image/png" });
+      const url = await up.upload(file, fname);
+      results.push({ store, ok: true, url });
+    } catch (e) {
+      results.push({ store, ok: false, phase: "upload", err: String(e?.message || e).slice(0, 200) });
+    }
+  }
+
+  plugin.settings.imageStore = originalStore;
+  plugin.setupImageUploader();
+  return JSON.stringify(results, null, 2);
+})()

--- a/scripts/e2e/cdp-e2e-supplemental.js
+++ b/scripts/e2e/cdp-e2e-supplemental.js
@@ -1,0 +1,336 @@
+// Comprehensive supplementary E2E suite for image-upload-toolkit.
+//
+// Covers 13 cases:
+//   1.  Settings panel renders without throwing (and headings aren't ALL CAPS)
+//   2.  Progress modal appears when showProgressModal=true and images>0
+//   3.  Web image downloaded + uploaded when uploadWebImages=true
+//   4.  Web image skipped when uploadWebImages=false
+//   5.  Multi mermaid block + dark theme + scale=3
+//   6.  Mermaid theme=forest renders & uploads
+//   7.  replaceOriginalDoc=true rewrites the editor buffer
+//   8.  Wiki-link image syntax ![[name.png]] is uploaded & rewritten
+//   9.  Already-hosted image NOT re-uploaded (short-circuit)
+//   10. ignoreProperties=true strips YAML frontmatter from clipboard output
+//   11. ignoreProperties=false keeps YAML frontmatter
+//   12. imageAltText=true populates alt text from filename
+//   13. imageAltText=false produces empty alt text
+//
+// Usage:
+//   ./scripts/e2e/cdp.sh "$(cat scripts/e2e/cdp-e2e-supplemental.js)"
+//
+// Configuration:
+//   - Edit STORE_ID and BUCKET_HOST_RE below to match the store you have
+//     creds for in the running vault. BUCKET_HOST_RE is used to assert
+//     that uploaded URLs land on the expected host.
+//
+// Notes:
+//   - All cases run in a fresh setup() that snapshots & restores
+//     plugin.settings.
+//   - Temp notes/images are tracked in tmpFiles and deleted at the end.
+//   - The run uploads to your real bucket — sentinel filenames are
+//     prefixed `__iut-` so they're easy to identify and prune.
+
+(async () => {
+  const STORE_ID       = "ALIYUN_OSS";  // canonical ID from src/imageStore.ts
+  const BUCKET_HOST_RE = /oss-cn-hangzhou\.aliyuncs\.com/;  // regex matching uploaded URL host
+
+  const plugin = app.plugins.plugins["image-upload-toolkit"];
+  if (!plugin) throw new Error("image-upload-toolkit plugin not loaded");
+
+  const origSettings = JSON.parse(JSON.stringify(plugin.settings));
+  const results = [];
+  const log = (name, ok, detail) => results.push({ name, ok, detail });
+  const tmpFiles = [];
+
+  const setup = (overrides = {}) => {
+    Object.assign(plugin.settings, {
+      imageStore: STORE_ID,
+      convertMermaid: false,
+      showProgressModal: false,
+      uploadWebImages: false,
+      replaceOriginalDoc: false,
+      ignoreProperties: true,
+      imageAltText: true,
+    }, overrides);
+    plugin.setupImageUploader();
+  };
+
+  const createNote = async (name, content) => {
+    const f = await app.vault.create(name, content);
+    tmpFiles.push(f);
+    const leaf = app.workspace.getLeaf(false);
+    await leaf.openFile(f);
+    await new Promise(r => setTimeout(r, 400));
+    return f;
+  };
+
+  const runPublishAndGetClip = async (timeoutMs = 30000) => {
+    await navigator.clipboard.writeText("");
+    app.commands.executeCommandById("image-upload-toolkit:publish-page");
+    const start = Date.now();
+    let clip = "";
+    while (Date.now() - start < timeoutMs) {
+      await new Promise(r => setTimeout(r, 400));
+      clip = await navigator.clipboard.readText();
+      if (clip && clip.length > 10) break;
+    }
+    return clip;
+  };
+
+  // ─────────────────────────────────────────────────────────────
+  // 1. Settings panel renders without throwing
+  // ─────────────────────────────────────────────────────────────
+  try {
+    const tab = app.setting;
+    tab.open();
+    tab.openTabById("image-upload-toolkit");
+    await new Promise(r => setTimeout(r, 600));
+    const container = tab.activeTab?.containerEl;
+    const settingItems = container?.querySelectorAll(".setting-item")?.length || 0;
+    const headings = [...(container?.querySelectorAll(".setting-item-heading") || [])]
+      .map(el => el.textContent?.trim()).filter(Boolean);
+    const hasShout = headings.some(h => h.length > 3 && h === h.toUpperCase());
+    tab.close();
+    log("settings_panel_renders", settingItems > 5 && !hasShout, { settingItems, headingCount: headings.length, sampleHeadings: headings.slice(0, 6) });
+  } catch (e) {
+    log("settings_panel_renders", false, { err: String(e?.message || e) });
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // 2. Progress modal appears
+  // ─────────────────────────────────────────────────────────────
+  try {
+    setup({ showProgressModal: true, uploadWebImages: true });
+    await createNote(`__iut-modal-${Date.now()}.md`,
+      "# modal test\n\n![web](https://placehold.co/3x3.png)\n");
+    await navigator.clipboard.writeText("");
+    app.commands.executeCommandById("image-upload-toolkit:publish-page");
+    let modalSeen = false;
+    let modalTitle = null;
+    let modalClasses = null;
+    for (let i = 0; i < 40; i++) {
+      await new Promise(r => setTimeout(r, 200));
+      const modal = activeDocument.querySelector(".modal.upload-progress-modal");
+      if (modal) {
+        modalSeen = true;
+        modalClasses = modal.className;
+        const titleEl = activeDocument.querySelector(".modal.upload-progress-modal .modal-title")
+          || activeDocument.querySelector(".modal-container .modal-title");
+        modalTitle = titleEl?.textContent?.trim() || null;
+        break;
+      }
+    }
+    await new Promise(r => setTimeout(r, 6000));
+    log("progress_modal_appears", modalSeen, { modalTitle, modalClasses });
+  } catch (e) {
+    log("progress_modal_appears", false, { err: String(e?.message || e) });
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // 3. Web image download + upload
+  // ─────────────────────────────────────────────────────────────
+  try {
+    setup({ uploadWebImages: true });
+    await createNote(`__iut-webimg-${Date.now()}.md`,
+      "# web image test\n\n![remote](https://placehold.co/4x4.png)\n");
+    const clip = await runPublishAndGetClip();
+    const hasHostedUrl = BUCKET_HOST_RE.test(clip);
+    const noPlaceholdLink = !/placehold\.co/.test(clip);
+    log("web_image_download_upload", hasHostedUrl && noPlaceholdLink, { snippet: clip.slice(0, 250) });
+  } catch (e) {
+    log("web_image_download_upload", false, { err: String(e?.message || e) });
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // 4. Web image SKIPPED when uploadWebImages=false
+  // ─────────────────────────────────────────────────────────────
+  try {
+    setup({ uploadWebImages: false });
+    await createNote(`__iut-webimg-skip-${Date.now()}.md`,
+      "# skip test\n\n![remote](https://placehold.co/4x4.png)\n");
+    const clip = await runPublishAndGetClip(8000);
+    const stillHasOriginal = /placehold\.co/.test(clip);
+    const noUploadedUrl = !BUCKET_HOST_RE.test(clip);
+    log("web_image_skipped_when_disabled", stillHasOriginal && noUploadedUrl, { snippet: clip.slice(0, 200) });
+  } catch (e) {
+    log("web_image_skipped_when_disabled", false, { err: String(e?.message || e) });
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // 5. Multi mermaid blocks + dark theme + scale=3
+  // ─────────────────────────────────────────────────────────────
+  try {
+    setup({ convertMermaid: true });
+    plugin.settings.mermaidTheme = "dark";
+    plugin.settings.mermaidScale = 3;
+    plugin.setupImageUploader();
+    await createNote(`__iut-mer-multi-${Date.now()}.md`,
+      "# multi mermaid\n\n```mermaid\nflowchart LR\nA-->B\n```\n\n```mermaid\nsequenceDiagram\nAlice->>Bob: hi\nBob-->>Alice: hello\n```\n\nend\n");
+    const clip = await runPublishAndGetClip(45000);
+    const pngs = clip.match(/https?:\/\/[^\s)]+mermaid-export-[^\s)]+\.png/g) || [];
+    const noFence = !/```mermaid/.test(clip);
+    log("mermaid_multi_block_dark_scale3", pngs.length === 2 && noFence, { pngCount: pngs.length, sample: pngs[0] });
+  } catch (e) {
+    log("mermaid_multi_block_dark_scale3", false, { err: String(e?.message || e) });
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // 6. Mermaid theme=forest
+  // ─────────────────────────────────────────────────────────────
+  try {
+    setup({ convertMermaid: true });
+    plugin.settings.mermaidTheme = "forest";
+    plugin.settings.mermaidScale = 2;
+    plugin.setupImageUploader();
+    await createNote(`__iut-mer-forest-${Date.now()}.md`,
+      "# forest\n\n```mermaid\nflowchart TD\nX-->Y\n```\n");
+    const clip = await runPublishAndGetClip(20000);
+    const ok = /mermaid-export-[^\s)]+\.png/.test(clip) && !/```mermaid/.test(clip);
+    log("mermaid_theme_forest", ok, { snippet: clip.slice(0, 250) });
+  } catch (e) {
+    log("mermaid_theme_forest", false, { err: String(e?.message || e) });
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // 7. replaceOriginalDoc=true rewrites the editor buffer
+  // ─────────────────────────────────────────────────────────────
+  try {
+    setup({ uploadWebImages: true, replaceOriginalDoc: true });
+    await createNote(`__iut-replace-${Date.now()}.md`,
+      "# replace test\n\n![pic](https://placehold.co/5x5.png)\n");
+    await runPublishAndGetClip(20000);
+    await new Promise(r => setTimeout(r, 1500));
+    // Read from the active editor (setValue does not auto-save to disk)
+    const leaf = app.workspace.activeLeaf;
+    let editorText = null;
+    if (leaf?.view?.editor?.getValue) {
+      editorText = leaf.view.editor.getValue();
+    } else if (leaf?.view?.getViewData) {
+      editorText = leaf.view.getViewData();
+    }
+    const editorRewritten = editorText && !/placehold\.co/.test(editorText) && BUCKET_HOST_RE.test(editorText);
+    log("replace_original_doc", !!editorRewritten, { editor: (editorText || "").slice(0, 250) });
+  } catch (e) {
+    log("replace_original_doc", false, { err: String(e?.message || e) });
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // 8. Wiki-link image upload ![[name.png]]
+  // ─────────────────────────────────────────────────────────────
+  try {
+    setup();
+    const b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==";
+    const bytes = Uint8Array.from(atob(b64), c => c.charCodeAt(0));
+    const imgName = `__iut-wiki-img-${Date.now()}.png`;
+    const imgFile = await app.vault.createBinary(imgName, bytes.buffer);
+    tmpFiles.push(imgFile);
+    await createNote(`__iut-wiki-${Date.now()}.md`,
+      `# wiki link\n\n![[${imgName}]]\n`);
+    const clip = await runPublishAndGetClip(15000);
+    const replaced = !/\[\[/.test(clip) && BUCKET_HOST_RE.test(clip);
+    log("wiki_link_image_upload", replaced, { snippet: clip.slice(0, 250) });
+  } catch (e) {
+    log("wiki_link_image_upload", false, { err: String(e?.message || e) });
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // 9. Already-hosted image is NOT re-uploaded
+  // ─────────────────────────────────────────────────────────────
+  try {
+    setup({ uploadWebImages: true });
+    // Construct a "hosted" URL that matches BUCKET_HOST_RE
+    const hostedHost = (BUCKET_HOST_RE.source || "").replace(/\\./g, ".").replace(/[^A-Za-z0-9.\-]/g, "");
+    const hosted = `https://${hostedHost || "example.com"}/static/already-hosted.png`;
+    await createNote(`__iut-hosted-${Date.now()}.md`,
+      `# hosted\n\n![hosted](${hosted})\n`);
+    const clip = await runPublishAndGetClip(8000);
+    const occurrences = (clip.match(new RegExp(hosted.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g")) || []).length;
+    const noNewTimestampedUpload = !new RegExp(`${BUCKET_HOST_RE.source}[^\\s]*\\/\\d{4}\\/\\d{2}\\/\\d{2}\\/already-hosted`).test(clip);
+    log("hosted_image_not_reuploaded", occurrences === 1 && noNewTimestampedUpload, { occurrences, snippet: clip.slice(0, 250) });
+  } catch (e) {
+    log("hosted_image_not_reuploaded", false, { err: String(e?.message || e) });
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // 10. ignoreProperties=true strips frontmatter
+  // ─────────────────────────────────────────────────────────────
+  try {
+    setup({ ignoreProperties: true });
+    await createNote(`__iut-fm-strip-${Date.now()}.md`,
+      "---\ntitle: x\ntags: [a,b]\n---\n\n# body only\n\nhello\n");
+    const clip = await runPublishAndGetClip(5000);
+    const stripped = !/^---/m.test(clip) && /# body only/.test(clip);
+    log("ignore_properties_strips_frontmatter", stripped, { snippet: clip.slice(0, 200) });
+  } catch (e) {
+    log("ignore_properties_strips_frontmatter", false, { err: String(e?.message || e) });
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // 11. ignoreProperties=false keeps frontmatter
+  // ─────────────────────────────────────────────────────────────
+  try {
+    setup({ ignoreProperties: false });
+    await createNote(`__iut-fm-keep-${Date.now()}.md`,
+      "---\ntitle: y\n---\n\n# kept\n");
+    const clip = await runPublishAndGetClip(5000);
+    const kept = /^---/m.test(clip) && /title: y/.test(clip);
+    log("ignore_properties_keeps_when_off", kept, { snippet: clip.slice(0, 200) });
+  } catch (e) {
+    log("ignore_properties_keeps_when_off", false, { err: String(e?.message || e) });
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // 12. imageAltText=true populates alt text from filename
+  // ─────────────────────────────────────────────────────────────
+  try {
+    setup({ imageAltText: true });
+    const b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==";
+    const bytes = Uint8Array.from(atob(b64), c => c.charCodeAt(0));
+    const imgName = `my-fancy_picture-${Date.now()}.png`;
+    const imgFile = await app.vault.createBinary(imgName, bytes.buffer);
+    tmpFiles.push(imgFile);
+    await createNote(`__iut-alt-${Date.now()}.md`,
+      `# alt\n\n![[${imgName}]]\n`);
+    const clip = await runPublishAndGetClip(15000);
+    const altMatch = clip.match(/!\[([^\]]+)\]\(https?:[^)]+\)/);
+    const altLooksFromName = !!altMatch && /fancy picture/.test(altMatch[1]);
+    log("image_alt_text_from_filename", altLooksFromName, { alt: altMatch?.[1], snippet: clip.slice(0, 250) });
+  } catch (e) {
+    log("image_alt_text_from_filename", false, { err: String(e?.message || e) });
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // 13. imageAltText=false produces empty alt
+  // ─────────────────────────────────────────────────────────────
+  try {
+    setup({ imageAltText: false });
+    const b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==";
+    const bytes = Uint8Array.from(atob(b64), c => c.charCodeAt(0));
+    const imgName = `no-alt-${Date.now()}.png`;
+    const imgFile = await app.vault.createBinary(imgName, bytes.buffer);
+    tmpFiles.push(imgFile);
+    await createNote(`__iut-noalt-${Date.now()}.md`,
+      `# noalt\n\n![[${imgName}]]\n`);
+    const clip = await runPublishAndGetClip(15000);
+    const altMatch = clip.match(/!\[([^\]]*)\]\(https?:[^)]+\)/);
+    const isEmpty = altMatch && altMatch[1] === "";
+    log("image_alt_text_empty_when_off", !!isEmpty, { alt: altMatch?.[1], snippet: clip.slice(0, 250) });
+  } catch (e) {
+    log("image_alt_text_empty_when_off", false, { err: String(e?.message || e) });
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // Cleanup
+  // ─────────────────────────────────────────────────────────────
+  for (const f of tmpFiles) {
+    try { await app.vault.delete(f); } catch {}
+  }
+  Object.assign(plugin.settings, origSettings);
+  plugin.setupImageUploader();
+
+  const passed = results.filter(r => r.ok).length;
+  return JSON.stringify({
+    summary: `${passed}/${results.length} passed`,
+    results
+  }, null, 2);
+})()

--- a/scripts/e2e/cdp-mermaid-e2e.js
+++ b/scripts/e2e/cdp-mermaid-e2e.js
@@ -1,0 +1,65 @@
+// Mermaid round-trip test.
+//
+// What it does:
+//   - Creates a temp note containing a mermaid code fence.
+//   - Configures Aliyun OSS as the backing store (adjust if needed).
+//   - Runs the `image-upload-toolkit:publish-page` command.
+//   - Asserts the clipboard output contains an uploaded PNG URL and that
+//     the original mermaid fence has been replaced.
+//   - Cleans up the temp note.
+//
+// Usage:
+//   ./scripts/e2e/cdp.sh "$(cat scripts/e2e/cdp-mermaid-e2e.js)"
+//
+// Pre-reqs:
+//   - Adjust `STORE_ID` below if you want to upload via a different store.
+//   - The store must have valid credentials configured in the vault.
+
+(async () => {
+  const STORE_ID = "ALIYUN_OSS";  // adjust to whichever store you have creds for
+
+  const plugin = app.plugins.plugins["image-upload-toolkit"];
+  if (!plugin) throw new Error("image-upload-toolkit plugin not loaded");
+
+  const origSettings = JSON.parse(JSON.stringify(plugin.settings));
+  plugin.settings.imageStore = STORE_ID;
+  plugin.settings.convertMermaid = true;
+  plugin.settings.showProgressModal = false;
+  plugin.setupImageUploader();
+
+  const fname = `__iut-e2e-mermaid-${Date.now()}.md`;
+  const content = "# E2E mermaid test\n\n```mermaid\nflowchart LR\n  A-->B\n  B-->C\n```\n\nend\n";
+  const file = await app.vault.create(fname, content);
+
+  try {
+    const leaf = app.workspace.getLeaf(false);
+    await leaf.openFile(file);
+    await new Promise(r => setTimeout(r, 500));
+
+    await navigator.clipboard.writeText("");
+    const ok = app.commands.executeCommandById("image-upload-toolkit:publish-page");
+    if (!ok) throw new Error("publish-page command failed to execute");
+
+    // Wait for upload to finish (poll clipboard)
+    let clip = "";
+    for (let i = 0; i < 30; i++) {
+      await new Promise(r => setTimeout(r, 500));
+      clip = await navigator.clipboard.readText();
+      if (clip && clip.length > 100) break;
+    }
+
+    const pngs = (clip.match(/https?:\/\/[^\s)]+\.png/g) || []);
+    const hasMermaidBlock = /```mermaid/.test(clip);
+    return JSON.stringify({
+      ok: pngs.length > 0 && !hasMermaidBlock,
+      png_urls: pngs,
+      mermaid_block_still_present: hasMermaidBlock,
+      clip_length: clip.length,
+      snippet: clip.slice(0, 400)
+    }, null, 2);
+  } finally {
+    try { await app.vault.delete(file); } catch {}
+    Object.assign(plugin.settings, origSettings);
+    plugin.setupImageUploader();
+  }
+})()

--- a/scripts/e2e/cdp.sh
+++ b/scripts/e2e/cdp.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Evaluate a JS expression inside the active Obsidian renderer over the
+# Chrome DevTools Protocol and print the result.
+#
+# Usage:
+#   PORT=9223 ./scripts/e2e/cdp.sh '<js expression>'
+#   ./scripts/e2e/cdp.sh "$(cat scripts/e2e/cdp-e2e-all.js)"
+#
+# Prerequisites:
+#   - Obsidian launched with --remote-debugging-port=$PORT
+#       open -a Obsidian --args --remote-debugging-port=9223
+#   - websocat on PATH       (brew install websocat)
+#   - python3 on PATH        (preinstalled on macOS)
+#
+# Notes:
+#   - The expression runs in the Obsidian renderer; `app`, `app.plugins`,
+#     `app.vault`, `activeDocument`, `navigator.clipboard`, etc. are in scope.
+#   - awaitPromise:true is set, so wrap multi-statement scripts in an
+#     async IIFE that returns a JSON-serializable value.
+#   - Do NOT use `require("obsidian")` or dynamically import the bundle from
+#     inside the expression — `obsidian` is an esbuild external and resolves
+#     to nothing at runtime in this context.
+
+set -e
+PORT="${PORT:-9223}"
+
+WS=$(curl -s "http://localhost:$PORT/json/list" | python3 -c "
+import json, sys
+pages = [t['webSocketDebuggerUrl'] for t in json.load(sys.stdin) if t['type'] == 'page']
+if not pages:
+    sys.exit('no page target found on port $PORT — is Obsidian running with --remote-debugging-port?')
+print(pages[0])
+")
+
+EXPR="$1"
+if [ -z "$EXPR" ]; then
+    echo "usage: $0 '<js expression>'" >&2
+    exit 1
+fi
+
+PAYLOAD=$(python3 -c "
+import json, sys
+print(json.dumps({
+    'id': 1,
+    'method': 'Runtime.evaluate',
+    'params': {
+        'expression': sys.argv[1],
+        'returnByValue': True,
+        'awaitPromise': True,
+    }
+}))
+" "$EXPR")
+
+echo "$PAYLOAD" | websocat -n1 "$WS" | python3 -c "
+import json, sys
+r = json.load(sys.stdin)
+if 'result' in r and 'result' in r['result']:
+    v = r['result']['result']
+    if v.get('type') == 'string':
+        print(v.get('value', ''))
+    elif 'value' in v:
+        print(json.dumps(v['value'], indent=2, ensure_ascii=False))
+    else:
+        print(json.dumps(v, indent=2, ensure_ascii=False))
+    if r['result'].get('exceptionDetails'):
+        print('EXCEPTION:', json.dumps(r['result']['exceptionDetails'], indent=2), file=sys.stderr)
+        sys.exit(2)
+else:
+    print(json.dumps(r, indent=2), file=sys.stderr)
+    sys.exit(1)
+"


### PR DESCRIPTION
## Summary

Follow-up to #73. The CDP-based E2E workflow documented in `AGENTS.md` referenced helper scripts (`/tmp/cdp.sh`, `/tmp/cdp-e2e-all.js`, etc.) that only existed on the author's machine — anyone trying to reproduce the workflow had nothing to start from, and `/tmp/` on macOS is wiped on reboot.

This PR checks the working scripts into the repo and rewrites `AGENTS.md` to point at them by relative path.

## What's new

`scripts/e2e/`:
- **`cdp.sh`** — the `Runtime.evaluate` helper. Requires `websocat` + `python3`. `PORT` env var overridable. Exits non-zero on CDP exception or HTTP/WS failure (was silently swallowing errors before).
- **`cdp-e2e-all.js`** — multi-store upload smoke test (iterates stores from a list at the top of the file, uploads a 1×1 PNG sentinel via each).
- **`cdp-mermaid-e2e.js`** — mermaid round-trip; `STORE_ID` parameterised at the top.
- **`cdp-e2e-supplemental.js`** — 13-case suite covering settings panel rendering, progress modal lifecycle, web image download/skip, multi-block mermaid + theme/scale, `replaceOriginalDoc`, wiki-link images, hosted-URL dedupe, `ignoreProperties` toggle, and `imageAltText` toggle. `STORE_ID` and `BUCKET_HOST_RE` parameterised at the top so the assertions no longer hardcode `atbug.oss-cn-hangzhou.aliyuncs.com`.
- **`README.md`** — full workflow, prereqs (`websocat`, port), the `cdp.sh` invocation patterns, plugin hot-reload snippet, footguns (`require("obsidian")`, `editor.setValue()` persistence, `checkCallback`, async modal), cleanup expectations, and the canonical `ImageStore.id` + setting-key table.

## What's removed from AGENTS.md

The "End-to-End Testing via Chrome DevTools Protocol" section is now a short pointer to `scripts/e2e/README.md` plus a few footguns worth knowing without opening the README. The following moved out:
- The embedded `cdp.sh` source (and the inaccurate `jq` reference — the real helper uses `python3`)
- All `/tmp/cdp-*.js` references
- The duplicated canonical-ID table (now lives in `scripts/e2e/README.md`)
- The "Reload Plugin via CDP" code block

Net diff on AGENTS.md: −85 / +24 lines.

## Other changes

- `eslint.config.mjs`: add `scripts/**` to `globalIgnores`. The CDP scripts are not TypeScript and execute inside the Obsidian renderer, not Node — they shouldn't trip type-aware lint rules.

## Verification

- `npm run lint`: 0 errors, 137 warnings (same as `main`)
- `npm run build`: passes
- `bash -n scripts/e2e/cdp.sh`: syntax OK
- `scripts/e2e/cdp.sh` has execute bit set

## Test plan

- Docs + non-bundled assets only; no impact on `main.js`
- CI runs lint + test + build on identical source
