### PR TITLE
feat: process HTML image tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 ## ✨ Features
 
 ### Core Functionality
-- ✅ **Smart Image Detection** - Automatically recognizes Markdown and Wiki link formats
+- ✅ **Smart Image Detection** - Automatically recognizes Markdown, Wiki link, and optional HTML image tag formats
 - ✅ **Multi-Format Support** - PNG, JPG, JPEG, GIF, SVG, WebP, Excalidraw
 - ✅ **Batch Processing** - Upload multiple images simultaneously
 - ✅ **Real-Time Progress** - Optional progress modal with detailed feedback
@@ -68,6 +68,7 @@ Perfect for publishing to static sites like [GitHub Pages](https://pages.github.
 - **Ignore note properties**: ✅ Recommended (removes frontmatter when publishing)
 - **Show progress modal**: ✅ Recommended (better user experience)
 - **Upload web images**: ❌ Optional (downloads and re-uploads web images to prevent link rot)
+- **Process HTML image tags**: ❌ Optional (uploads images in `<img>` tags and preserves `alt` and other attributes)
 - **Convert mermaid diagrams**: ❌ Optional (converts mermaid code blocks to PNG images during publish)
 - **Mermaid scale**: 2 (image resolution multiplier, 1-4x)
 - **Mermaid theme**: default (options: default/dark/forest/neutral/base)
@@ -91,6 +92,7 @@ Select your preferred storage service from the dropdown. See [Storage Service Co
 - **Relative Paths**: Support for `./` and `../` relative path formats
 - **Dynamic Attachments**: Works with Obsidian's attachment folder settings
 - **Web Image Upload**: Enable in settings to automatically download and re-upload web images (http/https URLs) to your storage service. Images already hosted on your configured storage are automatically skipped.
+- **HTML Image Tags**: Enable in settings to upload images referenced by `<img src="...">`; only the `src` attribute is replaced, so `alt`, `width`, and other attributes stay intact.
 
 ## 🔧 Storage Service Configuration
 

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -28,6 +28,7 @@ export interface PublishSettings {
     imageStore: string;
     showProgressModal: boolean; // New setting to control progress modal display
     uploadWebImages: boolean; // New setting to enable web image upload
+    processHtmlImageTags: boolean; // Process HTML <img> tags in notes
     convertMermaid: boolean; // Convert mermaid code blocks to PNG images on publish
     mermaidScale: number; // Canvas scale factor for mermaid PNG export (1–4, default 2)
     mermaidTheme: string; // Mermaid render theme: default, dark, forest, neutral, base
@@ -51,6 +52,7 @@ const DEFAULT_SETTINGS: PublishSettings = {
     imageStore: ImageStore.IMGUR.id,
     showProgressModal: true, // Default to showing the modal
     uploadWebImages: false, // Default to disabled for backward compatibility
+    processHtmlImageTags: false, // Default to disabled for backward compatibility
     convertMermaid: false, // Default to disabled
     mermaidScale: 2, // 2x for crisp output on retina displays
     mermaidTheme: "default",

--- a/src/ui/publishSettingTab.ts
+++ b/src/ui/publishSettingTab.ts
@@ -69,6 +69,15 @@ export default class PublishSettingTab extends PluginSettingTab {
                     .onChange(value => this.plugin.settings.uploadWebImages = value)
             );
 
+        new Setting(containerEl)
+            .setName("Process HTML image tags")
+            .setDesc("Upload images referenced by HTML <img> tags and replace only the src attribute, preserving alt and other attributes.")
+            .addToggle(toggle =>
+                toggle
+                    .setValue(this.plugin.settings.processHtmlImageTags)
+                    .onChange(value => this.plugin.settings.processHtmlImageTags = value)
+            );
+
         // ── Mermaid ──
         new Setting(containerEl).setName("Mermaid").setHeading();
 

--- a/src/uploader/imageTagProcessor.ts
+++ b/src/uploader/imageTagProcessor.ts
@@ -10,7 +10,78 @@ import {errorMessage} from "./errorUtils";
 
 export const MD_REGEX = /!\[([^\]]*)\]\(([^)]*)\)/g;
 export const WIKI_REGEX = /!\[\[(.*?\.(png|jpg|jpeg|gif|svg|webp|excalidraw))(|.*)?\]\]/g;
+export const HTML_IMG_REGEX = /<img\b[^>]*\bsrc\s*=\s*(?:(['"])(.*?)\1|([^\s>]+))[^>]*>/gi;
 export const PROPERTIES_REGEX = /^---[\s\S]+?---\n/;
+const LOCAL_IMAGE_EXTENSION_REGEX = /\.(png|jpg|jpeg|gif|svg|webp|excalidraw)$/i;
+
+export interface HtmlImageReference {
+    source: string;
+    src: string;
+}
+
+export interface UploadedImageReference {
+    source: string;
+    url: string;
+    htmlSrc?: string;
+}
+
+/**
+ * Return HTML image references that can be processed by the uploader.
+ *
+ * @example
+ * getHtmlImageReferences('<img src="Anexos/files/a.png" alt="A">')
+ */
+export function getHtmlImageReferences(value: string): HtmlImageReference[] {
+    return [...value.matchAll(HTML_IMG_REGEX)]
+        .map(match => ({source: match[0], src: match[2] || match[3] || ""}))
+        .filter(image => image.src.length > 0);
+}
+
+/**
+ * Check whether a local path points to an image extension supported by Obsidian.
+ *
+ * @example
+ * isSupportedLocalImagePath("Anexos/files/Pasted image.png")
+ */
+export function isSupportedLocalImagePath(imagePath: string): boolean {
+    const localPath = imagePath.split("?")[0].split("#")[0];
+    return LOCAL_IMAGE_EXTENSION_REGEX.test(localPath);
+}
+
+/**
+ * Replace only the src attribute inside an HTML image tag.
+ *
+ * @example
+ * replaceHtmlImageTagSrc('<img src="a.png" alt="A">', 'https://cdn/a.png')
+ */
+export function replaceHtmlImageTagSrc(imageTag: string, remoteUrl: string): string {
+    const quotedSrc = imageTag.replace(/(\bsrc\s*=\s*)(["'])(.*?)\2/i, (_match, prefix, quote) => `${prefix}${quote}${remoteUrl}${quote}`);
+    if (quotedSrc !== imageTag) return quotedSrc;
+    return imageTag.replace(/(\bsrc\s*=\s*)([^\s>]+)/i, (_match, prefix) => `${prefix}${remoteUrl}`);
+}
+
+/**
+ * Format an uploaded image as Markdown or as the original HTML tag shape.
+ *
+ * @example
+ * formatUploadedImageReference({source: "![a](a.png)", url: "https://cdn/a.png"}, "a")
+ */
+export function formatUploadedImageReference(image: UploadedImageReference, altText: string): string {
+    if (image.htmlSrc) return replaceHtmlImageTagSrc(image.source, image.url);
+    return `![${altText}](${image.url})`;
+}
+
+/**
+ * Resolve a note-relative image path to a vault path when metadata misses.
+ *
+ * @example
+ * resolveRelativeVaultPath("files/a.png", "Notes/example.md")
+ */
+export function resolveRelativeVaultPath(imagePath: string, sourcePath: string): string {
+    if (!sourcePath || imagePath.startsWith("/")) return normalizePath(imagePath);
+    const sourceDir = sourcePath.split("/").slice(0, -1).join("/");
+    return normalizePath(path.posix.join(sourceDir, imagePath));
+}
 
 export function isAlreadyHosted(url: string, settings: PublishSettings): boolean {
     try {
@@ -63,11 +134,9 @@ export function isAlreadyHosted(url: string, settings: PublishSettings): boolean
     }
 }
 
-interface Image {
+interface Image extends UploadedImageReference {
     name: string;
     path: string;
-    url: string;
-    source: string;
     isWebImage?: boolean; // Flag to indicate if this is a web image
 }
 
@@ -206,24 +275,24 @@ export default class ImageTagProcessor {
             })));
             successfulImages = results.filter(img => img !== null) as Image[];
 
-            let altText;
+            let altText: string;
             for (const image of successfulImages) {
                 altText = this.settings.imageAltText ?
                     path.parse(image.name)?.name?.replaceAll("-", " ")?.replaceAll("_", " ") :
                     '';
-                value = value.replaceAll(image.source, `![${altText}](${image.url})`);
+                value = value.replaceAll(image.source, formatUploadedImageReference(image, altText));
             }
         }
 
         if (this.settings.replaceOriginalDoc) {
             if (successfulImages.length > 0 && this.getEditor()) {
                 let docValue = this.getValue();
-                let altText;
+                let altText: string;
                 for (const image of successfulImages) {
                     altText = this.settings.imageAltText ?
                         path.parse(image.name)?.name?.replaceAll("-", " ")?.replaceAll("_", " ") :
                         '';
-                    docValue = docValue.replaceAll(image.source, `![${altText}](${image.url})`);
+                    docValue = docValue.replaceAll(image.source, formatUploadedImageReference(image, altText));
                 }
                 this.getEditor()?.setValue(docValue);
             }
@@ -231,12 +300,12 @@ export default class ImageTagProcessor {
             const webImages = successfulImages.filter(img => img.isWebImage);
             if (webImages.length > 0 && this.getEditor()) {
                 let docValue = this.getValue();
-                let altText;
+                let altText: string;
                 for (const image of webImages) {
                     altText = this.settings.imageAltText ?
                         path.parse(image.name)?.name?.replaceAll("-", " ")?.replaceAll("_", " ") :
                         '';
-                    docValue = docValue.replaceAll(image.source, `![${altText}](${image.url})`);
+                    docValue = docValue.replaceAll(image.source, formatUploadedImageReference(image, altText));
                 }
                 this.getEditor()?.setValue(docValue);
             }
@@ -280,13 +349,19 @@ export default class ImageTagProcessor {
                 }
                 
                 // Skip non-image local files (e.g., .pdf, .txt) to prevent invalid uploads
-                const localPath = imageUrl.split('?')[0];
-                if (!/\.(png|jpg|jpeg|gif|svg|webp|excalidraw)$/i.test(localPath)) {
+                if (!isSupportedLocalImagePath(imageUrl)) {
                     continue;
                 }
 
                 const decodedName = decodeURI(imageUrl);
                 this.processMatched(decodedName, match[0], images);
+            }
+
+            if (this.settings.processHtmlImageTags) {
+                const htmlImages = getHtmlImageReferences(value);
+                for (const image of htmlImages) {
+                    this.processHtmlImage(image, images, mermaidUrls);
+                }
             }
         } catch (error) {
             console.error("Error processing image lists:", error);
@@ -295,7 +370,20 @@ export default class ImageTagProcessor {
         return images;
     }
 
-    private processMatched(path: string, src: string, images: Image[]){    
+    private processHtmlImage(image: HtmlImageReference, images: Image[], mermaidUrls: Set<string>) {
+        if (WebImageDownloader.isWebImage(image.src)) {
+            if (this.settings.uploadWebImages && !this.isAlreadyHosted(image.src) && !mermaidUrls.has(image.src)) {
+                this.processWebImage(image.src, image.source, images, image.src);
+            }
+            return;
+        }
+
+        if (isSupportedLocalImagePath(image.src)) {
+            this.processMatched(decodeURI(image.src), image.source, images, image.src);
+        }
+    }
+
+    private processMatched(path: string, src: string, images: Image[], htmlSrc?: string){    
         try {
             const {resolvedPath, name} = this.resolveImagePath(path);
             // check the item with same resolvedPath 
@@ -306,6 +394,7 @@ export default class ImageTagProcessor {
                     path: resolvedPath,
                     source: src,
                     url: '',
+                    htmlSrc,
                 });
             }
         } catch (error) {
@@ -316,7 +405,7 @@ export default class ImageTagProcessor {
     /**
      * Process web image URL
      */
-    private processWebImage(url: string, src: string, images: Image[]) {
+    private processWebImage(url: string, src: string, images: Image[], htmlSrc?: string) {
         try {
             // Extract a friendly name from URL
             const urlObj = new URL(url);
@@ -332,7 +421,8 @@ export default class ImageTagProcessor {
                     path: url, // Store the URL as path for web images
                     source: src,
                     url: '',
-                    isWebImage: true
+                    isWebImage: true,
+                    htmlSrc
                 });
             }
         } catch (error) {
@@ -355,7 +445,15 @@ export default class ImageTagProcessor {
         if (targetFile) {
             return {resolvedPath: targetFile.path, name: imageName};
         }
-        return {resolvedPath: imageName, name: imageName};
+        const normalizedImageName = normalizePath(imageName);
+        if (this.app.vault.getAbstractFileByPath(normalizedImageName)) {
+            return {resolvedPath: normalizedImageName, name: imageName};
+        }
+        const relativePath = resolveRelativeVaultPath(normalizedImageName, sourcePath);
+        if (this.app.vault.getAbstractFileByPath(relativePath)) {
+            return {resolvedPath: relativePath, name: imageName};
+        }
+        return {resolvedPath: normalizedImageName, name: imageName};
 
     }
 

--- a/tests/unit/imageTagProcessor.test.ts
+++ b/tests/unit/imageTagProcessor.test.ts
@@ -1,0 +1,74 @@
+import {describe, expect, it, vi} from "vitest";
+import ImageStore from "../../src/imageStore";
+import ImageTagProcessor from "../../src/uploader/imageTagProcessor";
+import type {PublishSettings} from "../../src/publish";
+
+const GTM_NOTE_IMAGE = '<img src="Anexos/files/Pasted image 20260702143718.png" alt="Google Tag Manager mostrando container SSG SHOP VTEX">';
+
+function makeSettings(processHtmlImageTags: boolean): PublishSettings {
+    return {
+        imageStore: ImageStore.IMGUR.id,
+        processHtmlImageTags,
+        uploadWebImages: false,
+    } as PublishSettings;
+}
+
+function makeProcessor(processHtmlImageTags: boolean, existingPaths: string[]): ImageTagProcessor {
+    const existingPathSet = new Set(existingPaths);
+    const app = {
+        vault: {
+            adapter: {
+                getBasePath: () => "/mock/vault",
+                readBinary: vi.fn(),
+            },
+            getAbstractFileByPath: vi.fn(path => existingPathSet.has(path)),
+        },
+        workspace: {
+            getActiveFile: () => ({path: "Sansung/E-mails/Validacao de consolidacao das tags Google no GTM.md"}),
+            getActiveViewOfType: vi.fn(),
+        },
+        metadataCache: {
+            getFirstLinkpathDest: vi.fn(),
+        },
+    };
+    const uploader = {upload: vi.fn()};
+    return new ImageTagProcessor(app as any, makeSettings(processHtmlImageTags), uploader as any, false);
+}
+
+function collectImages(processor: ImageTagProcessor, markdown: string) {
+    return (processor as any).getImageLists(markdown);
+}
+
+describe("ImageTagProcessor HTML image tags", () => {
+    it("ignores HTML image tags when the setting is disabled", () => {
+        const processor = makeProcessor(false, ["Anexos/files/Pasted image 20260702143718.png"]);
+
+        expect(collectImages(processor, GTM_NOTE_IMAGE)).toEqual([]);
+    });
+
+    it("collects root vault HTML image tags when the setting is enabled", () => {
+        const processor = makeProcessor(true, ["Anexos/files/Pasted image 20260702143718.png"]);
+
+        expect(collectImages(processor, GTM_NOTE_IMAGE)).toEqual([
+            {
+                name: "Anexos/files/Pasted image 20260702143718.png",
+                path: "Anexos/files/Pasted image 20260702143718.png",
+                source: GTM_NOTE_IMAGE,
+                url: "",
+                htmlSrc: "Anexos/files/Pasted image 20260702143718.png",
+            },
+        ]);
+    });
+
+    it("falls back to active-note relative paths for HTML image tags", () => {
+        const processor = makeProcessor(true, ["Sansung/E-mails/Anexos/files/Pasted image.png"]);
+        const imageTag = '<img src="Anexos/files/Pasted image.png" alt="Relative image">';
+
+        expect(collectImages(processor, imageTag)[0]).toMatchObject({
+            name: "Anexos/files/Pasted image.png",
+            path: "Sansung/E-mails/Anexos/files/Pasted image.png",
+            source: imageTag,
+            htmlSrc: "Anexos/files/Pasted image.png",
+        });
+    });
+});

--- a/tests/unit/imageTagRegex.test.ts
+++ b/tests/unit/imageTagRegex.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { MD_REGEX, PROPERTIES_REGEX, WIKI_REGEX } from "../../src/uploader/imageTagProcessor";
+import {
+  formatUploadedImageReference,
+  getHtmlImageReferences,
+  HTML_IMG_REGEX,
+  isSupportedLocalImagePath,
+  MD_REGEX,
+  PROPERTIES_REGEX,
+  replaceHtmlImageTagSrc,
+  resolveRelativeVaultPath,
+  WIKI_REGEX,
+} from "../../src/uploader/imageTagProcessor";
 
 const fresh = (regex: RegExp) => new RegExp(regex.source, regex.flags);
 
@@ -86,6 +96,64 @@ describe("WIKI_REGEX", () => {
     const match = regex.exec("![[path/to/file.jpeg|500]]");
 
     expect(match?.[1]).toBe("path/to/file.jpeg");
+  });
+});
+
+describe("HTML_IMG_REGEX", () => {
+  it("captures quoted and unquoted src values", () => {
+    const html = [
+      '<img src="Anexos/files/Pasted image 20260702143718.png" alt="Google Tag Manager">',
+      "<img alt='Waterfall' src='Anexos/files/Pasted image 20260702121353.png'>",
+      "<img src=Anexos/files/plain.webp loading=lazy>",
+    ].join("\n");
+    const matches = [...html.matchAll(fresh(HTML_IMG_REGEX))];
+
+    expect(matches.map(match => match[2] || match[3])).toEqual([
+      "Anexos/files/Pasted image 20260702143718.png",
+      "Anexos/files/Pasted image 20260702121353.png",
+      "Anexos/files/plain.webp",
+    ]);
+  });
+
+  it("returns HTML image references with original tags", () => {
+    const imageTag = '<img src="Anexos/files/Pasted image.png" alt="Existing alt">';
+
+    expect(getHtmlImageReferences(imageTag)).toEqual([
+      { source: imageTag, src: "Anexos/files/Pasted image.png" },
+    ]);
+  });
+});
+
+describe("HTML image replacement helpers", () => {
+  it("preserves HTML attributes and replaces only src", () => {
+    const imageTag = '<img alt="Anexos/files/Pasted image.png" src="Anexos/files/Pasted image.png" width="320">';
+
+    expect(replaceHtmlImageTagSrc(imageTag, "https://cdn.example.com/image.png"))
+      .toBe('<img alt="Anexos/files/Pasted image.png" src="https://cdn.example.com/image.png" width="320">');
+  });
+
+  it("formats HTML references as HTML and markdown references as markdown", () => {
+    const uploadedUrl = "https://cdn.example.com/image.png";
+
+    expect(formatUploadedImageReference({
+      source: '<img src="Anexos/files/image.png" alt="Existing alt">',
+      url: uploadedUrl,
+      htmlSrc: "Anexos/files/image.png",
+    }, "")).toBe('<img src="https://cdn.example.com/image.png" alt="Existing alt">');
+    expect(formatUploadedImageReference({
+      source: "![image](Anexos/files/image.png)",
+      url: uploadedUrl,
+    }, "image")).toBe("![image](https://cdn.example.com/image.png)");
+  });
+
+  it("recognizes image paths before query strings and anchors", () => {
+    expect(isSupportedLocalImagePath("Anexos/files/Pasted image.png?x=1#hash")).toBe(true);
+    expect(isSupportedLocalImagePath("Anexos/files/readme.md")).toBe(false);
+  });
+
+  it("resolves note-relative paths with Obsidian vault separators", () => {
+    expect(resolveRelativeVaultPath("Anexos/files/Pasted image.png", "Sansung/E-mails/Note.md"))
+      .toBe("Sansung/E-mails/Anexos/files/Pasted image.png");
   });
 });
 


### PR DESCRIPTION
## Summary

Adds optional support for images referenced with HTML `<img>` tags during publish.

The new `processHtmlImageTags` setting is disabled by default. When enabled, the plugin detects tags like:

```html
<img src="attachments/example.png" alt="Existing alt text" width="320">
```

It uploads the image through the existing upload flow and replaces only the `src` attribute with the remote URL. Other attributes such as `alt`, `width`, `height`, and `loading` are preserved.

This keeps the existing Markdown image and Wiki image behavior unchanged.

## Verification

- `npm run lint`
- `npm test`
- `npm run build`

Manual check:

1. Build and install the generated `dist/main.js` in an Obsidian vault.
2. Enable **Process HTML image tags** in the plugin settings.
3. Create a note with an existing local image referenced as:

   ```html
   <img src="attachments/example.png" alt="Existing alt text" width="320">
   ```

4. Run **Publish page**.
5. Confirm the image is uploaded and the note/clipboard output keeps the HTML tag while replacing only `src`.
