### PR TITLE
fix: encode custom domain object paths

### DIFF
--- a/src/uploader/uploaderUtils.ts
+++ b/src/uploader/uploaderUtils.ts
@@ -37,10 +37,20 @@ export class UploaderUtils {
                     return match.replace(domain, customDomainName);
                 })
             } else {
-                return `https://${customDomainName}/${url}`;
+                return `https://${customDomainName}/${this.encodePath(url)}`;
             }
         }
         return url;
+    }
+
+    private static encodePath(path: string): string {
+        return path.split('/').map((segment) => {
+            try {
+                return encodeURIComponent(decodeURIComponent(segment));
+            } catch {
+                return encodeURIComponent(segment);
+            }
+        }).join('/');
     }
 
     /**

--- a/tests/unit/uploaderUtils.test.ts
+++ b/tests/unit/uploaderUtils.test.ts
@@ -90,6 +90,24 @@ describe("UploaderUtils.customizeDomainName", () => {
     expect(result).toBe("https://cdn.example.com/path/to/file.png");
   });
 
+  it("encodes key-like URL path segments when wrapping with custom domain", () => {
+    const result = UploaderUtils.customizeDomainName(
+      "2026-07-04/Pasted image 20260704164521.png",
+      "cdn.example.com",
+    );
+
+    expect(result).toBe("https://cdn.example.com/2026-07-04/Pasted%20image%2020260704164521.png");
+  });
+
+  it("does not double encode already encoded key-like URL path segments", () => {
+    const result = UploaderUtils.customizeDomainName(
+      "2026-07-04/Pasted%20image%2020260704164521.png",
+      "cdn.example.com",
+    );
+
+    expect(result).toBe("https://cdn.example.com/2026-07-04/Pasted%20image%2020260704164521.png");
+  });
+
   it("keeps trailing slash behavior of custom domain", () => {
     const result = UploaderUtils.customizeDomainName(
       "https://old.example.com/path/file.png",


### PR DESCRIPTION
## Summary
- Encode key-like object paths when wrapping them with a custom domain.
- Prevent generated Markdown image URLs from containing raw spaces, for example `Pasted image ...png`.
- Avoid double-encoding path segments that are already URL-encoded.

## Why
When an uploader returns an object key and `customDomainName` is configured, `UploaderUtils.customizeDomainName()` builds the public URL as:

```text
https://<custom-domain>/<object-key>
```

If the object key contains spaces or other URL-sensitive characters, the generated Markdown image URL can be invalid or fail to render in Markdown renderers such as Obsidian preview.

Example before:

```text
https://cdn.example.com/2026-07-04/Pasted image 20260704164521.png
```

Example after:

```text
https://cdn.example.com/2026-07-04/Pasted%20image%2020260704164521.png
```

The implementation encodes each path segment and first decodes existing escapes, so already encoded paths such as `%20` are not double-encoded to `%2520`.

## Testing
- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run build`
- [x] Verified the regression test fails before the fix and passes after the fix.

## Notes
This keeps existing behavior for full URLs that already include a scheme and host. It only encodes key-like paths that are wrapped with a custom domain.
