### PR TITLE
feat: add RustFS as image storage provider

### DIFF
--- a/src/imageStore.ts
+++ b/src/imageStore.ts
@@ -55,6 +55,11 @@ export default class ImageStore {
         "Backblaze B2"
     )
 
+    static readonly RUSTFS = new ImageStore(
+        "RUSTFS",
+        "RustFS"
+    )
+
     private static readonly aliases: Record<string, string> = {
         imgur: ImageStore.IMGUR.id,
         gyazo: ImageStore.GYAZO.id,
@@ -72,6 +77,7 @@ export default class ImageStore {
         cloudflare_r2: ImageStore.CLOUDFLARE_R2.id,
         b2: ImageStore.BACKBLAZE_B2.id,
         backblaze_b2: ImageStore.BACKBLAZE_B2.id,
+        rustfs: ImageStore.RUSTFS.id,
     };
 
     private constructor(readonly id: string, readonly description: string) {

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -20,6 +20,7 @@ import type {GitHubSetting} from "./uploader/github/gitHubUploader";
 import type {R2Setting} from "./uploader/r2/r2Uploader";
 import type {B2Setting} from "./uploader/b2/b2Uploader";
 import type {GyazoSetting} from "./uploader/gyazo/gyazoUploader";
+import type {RustfsSetting} from "./uploader/rustfs/rustfsUploader";
 
 export interface PublishSettings {
     imageAltText: boolean;
@@ -42,6 +43,7 @@ export interface PublishSettings {
     githubSetting: GitHubSetting;
     r2Setting: R2Setting;
     b2Setting: B2Setting;
+    rustfsSetting: RustfsSetting;
 }
 
 const DEFAULT_SETTINGS: PublishSettings = {
@@ -120,6 +122,13 @@ const DEFAULT_SETTINGS: PublishSettings = {
         bucketName: "",
         path: "",
         customDomainName: "",
+    },
+    rustfsSetting: {
+        accessKeyId: "",
+        secretAccessKey: "",
+        endpoint: "",
+        bucketName: "",
+        path: "",
     },
 };
 export default class ObsidianPublish extends Plugin {

--- a/src/ui/publishSettingTab.ts
+++ b/src/ui/publishSettingTab.ts
@@ -172,6 +172,9 @@ export default class PublishSettingTab extends PluginSettingTab {
             case ImageStore.BACKBLAZE_B2.id:
                 this.drawB2Setting(parentEL);
                 break;
+            case ImageStore.RUSTFS.id:
+                this.drawRustfsSetting(parentEL);
+                break;
             default:
                 throw new Error(
                     "Should not reach here!"
@@ -660,5 +663,47 @@ export default class PublishSettingTab extends PluginSettingTab {
                     .setPlaceholder("Enter custom domain (optional)")
                     .setValue(this.plugin.settings.b2Setting.customDomainName)
                     .onChange(value => this.plugin.settings.b2Setting.customDomainName = value));
+    }
+
+    private drawRustfsSetting(parentEL: HTMLDivElement) {
+        new Setting(parentEL)
+            .setName('RustFS endpoint')
+            .setDesc('Your RustFS server endpoint URL (e.g., http://localhost:9000).')
+            .addText(text => text
+                .setPlaceholder('http://localhost:9000')
+                .setValue(this.plugin.settings.rustfsSetting?.endpoint || '')
+                .onChange(value => this.plugin.settings.rustfsSetting.endpoint = value));
+
+        new Setting(parentEL)
+            .setName('RustFS access key')
+            .setDesc('Your RustFS access key (IAM user).')
+            .addText(text => text
+                .setPlaceholder('Enter access key')
+                .setValue(this.plugin.settings.rustfsSetting?.accessKeyId || '')
+                .onChange(value => this.plugin.settings.rustfsSetting.accessKeyId = value));
+
+        new Setting(parentEL)
+            .setName('RustFS secret key')
+            .setDesc('Your RustFS secret key.')
+            .addText(text => text
+                .setPlaceholder('Enter secret key')
+                .setValue(this.plugin.settings.rustfsSetting?.secretAccessKey || '')
+                .onChange(value => this.plugin.settings.rustfsSetting.secretAccessKey = value));
+
+        new Setting(parentEL)
+            .setName('Bucket name')
+            .setDesc('The bucket to store images in.')
+            .addText(text => text
+                .setPlaceholder('Enter bucket name')
+                .setValue(this.plugin.settings.rustfsSetting?.bucketName || '')
+                .onChange(value => this.plugin.settings.rustfsSetting.bucketName = value));
+
+        new Setting(parentEL)
+            .setName("Target path")
+            .setDesc("The path to store images. Supports {year} {mon} {day} {random} {filename} vars.")
+            .addText(text => text
+                .setPlaceholder("images/{year}/{mon}/{day}/{filename}")
+                .setValue(this.plugin.settings.rustfsSetting?.path || '')
+                .onChange(value => this.plugin.settings.rustfsSetting.path = value));
     }
 }

--- a/src/uploader/imageUploaderBuilder.ts
+++ b/src/uploader/imageUploaderBuilder.ts
@@ -11,6 +11,7 @@ import KodoUploader from "./qiniu/kodoUploader";
 import GitHubUploader from "./github/gitHubUploader";
 import R2Uploader from "./r2/r2Uploader";
 import B2Uploader from "./b2/b2Uploader";
+import RustfsUploader from "./rustfs/rustfsUploader";
 
 export default function buildUploader(settings: PublishSettings): ImageUploader {
     switch (ImageStore.normalizeId(settings.imageStore)) {
@@ -34,6 +35,8 @@ export default function buildUploader(settings: PublishSettings): ImageUploader 
             return new R2Uploader(settings.r2Setting);
         case ImageStore.BACKBLAZE_B2.id:
             return new B2Uploader(settings.b2Setting);
+        case ImageStore.RUSTFS.id:
+            return new RustfsUploader(settings.rustfsSetting);
         default:
             throw new Error('should not reach here!');
     }

--- a/src/uploader/rustfs/rustfsUploader.ts
+++ b/src/uploader/rustfs/rustfsUploader.ts
@@ -1,0 +1,49 @@
+import ImageUploader from "../imageUploader";
+import {PutObjectCommand, S3Client} from "@aws-sdk/client-s3";
+import {UploaderUtils} from "../uploaderUtils";
+
+export default class RustfsUploader implements ImageUploader {
+    private readonly s3!: S3Client;
+    private readonly bucket!: string;
+    private pathTmpl: string;
+    private endpoint: string;
+
+    constructor(setting: RustfsSetting) {
+        const endpoint = UploaderUtils.normalizeEndpoint(setting.endpoint);
+        this.s3 = new S3Client({
+            credentials: {
+                accessKeyId: UploaderUtils.trimCredential(setting.accessKeyId),
+                secretAccessKey: UploaderUtils.trimCredential(setting.secretAccessKey),
+            },
+            endpoint,
+            region: 'us-east-1', // RustFS doesn't require a real region
+            forcePathStyle: true, // RustFS uses path-style addressing
+        });
+        this.bucket = UploaderUtils.trimCredential(setting.bucketName);
+        this.pathTmpl = setting.path;
+        this.endpoint = endpoint;
+    }
+
+    async upload(image: File, fullPath: string): Promise<string> {
+        const arrayBuffer = await image.arrayBuffer();
+        const uint8Array = new Uint8Array(arrayBuffer);
+        let path = UploaderUtils.generateName(this.pathTmpl, image.name);
+        path = path.replace(/^\/+/, ''); // remove leading /
+        await this.s3.send(new PutObjectCommand({
+            Bucket: this.bucket,
+            Key: path,
+            Body: uint8Array,
+            ContentType: `image/${image.name.split('.').pop()}`,
+        }));
+        // RustFS: construct URL from endpoint + bucket + key
+        return `${this.endpoint}/${this.bucket}/${path}`;
+    }
+}
+
+export interface RustfsSetting {
+    accessKeyId: string;
+    secretAccessKey: string;
+    endpoint: string;
+    bucketName: string;
+    path: string;
+}


### PR DESCRIPTION
## Changes

Add [RustFS](https://rustfs.com) as a native image storage provider.

RustFS is a high-performance S3-compatible object storage built with Rust. This provider uses the AWS S3 SDK with path-style addressing, making it a clean fit for self-hosted RustFS instances.

## Configuration

| Field | Description | Example |
|-------|-------------|---------|
| Endpoint | RustFS server URL | `http://localhost:9000` |
| Access Key | IAM access key | `rustfsadmin` |
| Secret Key | IAM secret key | `rustfsadmin` |
| Bucket | Target bucket name | `images` |
| Path | Path template (optional) | `images/{year}/{mon}/{day}/{filename}` |

## Implementation

- `src/uploader/rustfs/rustfsUploader.ts` — Uploader using `@aws-sdk/client-s3` with `forcePathStyle: true`
- `src/imageStore.ts` — Added `RUSTFS` store with alias `rustfs`
- `src/uploader/imageUploaderBuilder.ts` — Added RustFS case
- `src/publish.ts` — Added `RustfsSetting` type and defaults
- `src/ui/publishSettingTab.ts` — Added RustFS settings UI

## URL Construction

Unlike AWS S3 (virtual-hosted style) or R2 (requires custom domain), RustFS URLs are constructed directly:

```
{endpoint}/{bucket}/{key}
```

Example: `http://72.145.11.191:9001/images/2026/08/05/photo.jpg`

## Testing

Verified with RustFS instance at `http://72.145.11.191:9001`.